### PR TITLE
feat: bootstrap official Bruno CLI GitHub Action

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,43 @@
+name: Nightly CLI compatibility
+
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+jobs:
+  nightly:
+    name: Run smoke fixture against @usebruno/cli@latest
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Stage fixtures + start server
+        run: |
+          mkdir -p public
+          printf '%s' '{"status":"ok"}'   > public/health.json
+          printf '%s' '{"method":"GET"}' > public/echo.json
+          nohup python3 -m http.server 8080 --directory public > server.log 2>&1 &
+          for i in {1..20}; do
+            curl -sf http://127.0.0.1:8080/health.json > /dev/null && exit 0
+            sleep 0.5
+          done
+          cat server.log; exit 1
+
+      - name: Run action against @usebruno/cli@latest
+        id: bru
+        uses: ./
+        with:
+          bru-version: latest
+          working-directory: tests/collection
+          command: 'run health.bru echo.bru --env ci --sandbox developer'
+
+      - name: Assert passing fixture still passes
+        run: |
+          set -euo pipefail
+          test "${{ steps.bru.outputs.exit-code }}" = "0"
+          test "${{ steps.bru.outputs.failed }}" = "0"
+          test -f "${{ steps.bru.outputs.report-junit }}"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -40,4 +40,4 @@ jobs:
           set -euo pipefail
           test "${{ steps.bru.outputs.exit-code }}" = "0"
           test "${{ steps.bru.outputs.failed }}" = "0"
-          test -f tests/collection/bruno-junit.xml
+          test -f "${RUNNER_TEMP}/bruno-junit.xml"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -13,7 +13,7 @@ jobs:
       contents: read
       issues: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Stage fixtures + start server
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -40,4 +40,4 @@ jobs:
           set -euo pipefail
           test "${{ steps.bru.outputs.exit-code }}" = "0"
           test "${{ steps.bru.outputs.failed }}" = "0"
-          test -f "${{ steps.bru.outputs.report-junit }}"
+          test -f tests/collection/bruno-junit.xml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Publish action and auto-retag floating major (v1, v2, ...)
         uses: actions/publish-action@v0.4.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,19 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    name: Publish to Marketplace and retag major
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Publish action and auto-retag floating major (v1, v2, ...)
+        uses: actions/publish-action@v0.4.0
+        with:
+          source-tag: ${{ github.event.release.tag_name }}

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -1,0 +1,109 @@
+name: Smoke test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  pass-path:
+    name: Passing run (bru ${{ matrix.bru-version }})
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        bru-version: ['3.0.0', 'latest']
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Stage fixtures for local HTTP server
+        run: |
+          mkdir -p public
+          printf '%s' '{"status":"ok"}'   > public/health.json
+          printf '%s' '{"method":"GET"}' > public/echo.json
+
+      - name: Start local HTTP server
+        run: |
+          nohup python3 -m http.server 8080 --directory public > server.log 2>&1 &
+          for i in {1..20}; do
+            if curl -sf http://127.0.0.1:8080/health.json > /dev/null; then
+              echo "server up"; exit 0
+            fi
+            sleep 0.5
+          done
+          echo "server never came up"; cat server.log; exit 1
+
+      - name: Run passing requests only
+        id: bru
+        uses: ./
+        with:
+          bru-version: ${{ matrix.bru-version }}
+          working-directory: tests/collection
+          command: 'run health.bru echo.bru --env ci --sandbox developer'
+
+      - name: Assert outputs (passing case)
+        run: |
+          set -euo pipefail
+          echo "exit-code=${{ steps.bru.outputs.exit-code }}"
+          echo "passed=${{ steps.bru.outputs.passed }}"
+          echo "failed=${{ steps.bru.outputs.failed }}"
+          echo "total=${{ steps.bru.outputs.total }}"
+          echo "duration-ms=${{ steps.bru.outputs.duration-ms }}"
+          echo "report-junit=${{ steps.bru.outputs.report-junit }}"
+          echo "report-json=${{ steps.bru.outputs.report-json }}"
+          echo "report-html=${{ steps.bru.outputs.report-html }}"
+          test "${{ steps.bru.outputs.exit-code }}" = "0"
+          test "${{ steps.bru.outputs.failed }}" = "0"
+          test "${{ steps.bru.outputs.passed }}" -ge 2
+          test -f "${{ steps.bru.outputs.report-junit }}"
+          test "${{ steps.bru.outputs.duration-ms }}" -ge 0
+          test -z "${{ steps.bru.outputs.report-json }}"
+          test -z "${{ steps.bru.outputs.report-html }}"
+
+  fail-path:
+    name: Failing run propagates exit code (bru ${{ matrix.bru-version }})
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        bru-version: ['3.0.0', 'latest']
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Stage fixtures + start server
+        run: |
+          mkdir -p public
+          printf '%s' '{"status":"ok"}'   > public/health.json
+          printf '%s' '{"method":"GET"}' > public/echo.json
+          nohup python3 -m http.server 8080 --directory public > server.log 2>&1 &
+          for i in {1..20}; do
+            curl -sf http://127.0.0.1:8080/health.json > /dev/null && exit 0
+            sleep 0.5
+          done
+          cat server.log; exit 1
+
+      - name: Run intentionally failing collection (continue-on-error)
+        id: bru
+        continue-on-error: true
+        uses: ./
+        with:
+          working-directory: tests/collection
+          command: 'run --env ci --sandbox developer'
+
+      - name: Assert failure was surfaced
+        run: |
+          set -euo pipefail
+          echo "exit-code=${{ steps.bru.outputs.exit-code }}"
+          echo "passed=${{ steps.bru.outputs.passed }}"
+          echo "failed=${{ steps.bru.outputs.failed }}"
+          test "${{ steps.bru.outputs.exit-code }}" != "0"
+          test "${{ steps.bru.outputs.failed }}" -gt 0
+          test -f "${{ steps.bru.outputs.report-junit }}"
+          test "${{ steps.bru.outputs.duration-ms }}" -ge 0
+          test "${{ steps.bru.outcome }}" = "failure"

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -53,16 +53,11 @@ jobs:
           echo "failed=${{ steps.bru.outputs.failed }}"
           echo "total=${{ steps.bru.outputs.total }}"
           echo "duration-ms=${{ steps.bru.outputs.duration-ms }}"
-          echo "report-junit=${{ steps.bru.outputs.report-junit }}"
-          echo "report-json=${{ steps.bru.outputs.report-json }}"
-          echo "report-html=${{ steps.bru.outputs.report-html }}"
           test "${{ steps.bru.outputs.exit-code }}" = "0"
           test "${{ steps.bru.outputs.failed }}" = "0"
           test "${{ steps.bru.outputs.passed }}" -ge 2
-          test -f "${{ steps.bru.outputs.report-junit }}"
           test "${{ steps.bru.outputs.duration-ms }}" -ge 0
-          test -z "${{ steps.bru.outputs.report-json }}"
-          test -z "${{ steps.bru.outputs.report-html }}"
+          test -f tests/collection/bruno-junit.xml
 
   fail-path:
     name: Failing run propagates exit code (bru ${{ matrix.bru-version }})
@@ -104,6 +99,6 @@ jobs:
           echo "failed=${{ steps.bru.outputs.failed }}"
           test "${{ steps.bru.outputs.exit-code }}" != "0"
           test "${{ steps.bru.outputs.failed }}" -gt 0
-          test -f "${{ steps.bru.outputs.report-junit }}"
           test "${{ steps.bru.outputs.duration-ms }}" -ge 0
           test "${{ steps.bru.outcome }}" = "failure"
+          test -f tests/collection/bruno-junit.xml

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   pass-path:
-    name: Passing run (bru ${{ matrix.bru-version }})
+    name: Passing run + JUnit auto-inject (bru ${{ matrix.bru-version }})
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -37,7 +37,7 @@ jobs:
           done
           echo "server never came up"; cat server.log; exit 1
 
-      - name: Run passing requests only
+      - name: Run passing requests only (command lacks --reporter-junit; expect auto-inject)
         id: bru
         uses: ./
         with:
@@ -45,7 +45,7 @@ jobs:
           working-directory: tests/collection
           command: 'run health.bru echo.bru --env ci --sandbox developer'
 
-      - name: Assert outputs (passing case)
+      - name: Assert outputs + auto-injected JUnit landed in $RUNNER_TEMP
         run: |
           set -euo pipefail
           echo "exit-code=${{ steps.bru.outputs.exit-code }}"
@@ -57,10 +57,12 @@ jobs:
           test "${{ steps.bru.outputs.failed }}" = "0"
           test "${{ steps.bru.outputs.passed }}" -ge 2
           test "${{ steps.bru.outputs.duration-ms }}" -ge 0
-          test -f tests/collection/bruno-junit.xml
+          test -n "${RUNNER_TEMP:-}"
+          test -f "${RUNNER_TEMP}/bruno-junit.xml"
+          test ! -e tests/collection/bruno-junit.xml
 
   fail-path:
-    name: Failing run propagates exit code (bru ${{ matrix.bru-version }})
+    name: Failing run + JUnit <error> counts as failed (bru ${{ matrix.bru-version }})
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -83,7 +85,7 @@ jobs:
           done
           cat server.log; exit 1
 
-      - name: Run intentionally failing collection (continue-on-error)
+      - name: Run full collection (includes intentional-fail.bru + network-error.bru)
         id: bru
         continue-on-error: true
         uses: ./
@@ -91,14 +93,53 @@ jobs:
           working-directory: tests/collection
           command: 'run --env ci --sandbox developer'
 
-      - name: Assert failure was surfaced
+      - name: Assert exit propagation, fail counts, and <error> handling
         run: |
           set -euo pipefail
           echo "exit-code=${{ steps.bru.outputs.exit-code }}"
           echo "passed=${{ steps.bru.outputs.passed }}"
           echo "failed=${{ steps.bru.outputs.failed }}"
+          echo "total=${{ steps.bru.outputs.total }}"
+          echo "duration-ms=${{ steps.bru.outputs.duration-ms }}"
           test "${{ steps.bru.outputs.exit-code }}" != "0"
-          test "${{ steps.bru.outputs.failed }}" -gt 0
+          test "${{ steps.bru.outputs.failed }}" -ge 2
+          test "${{ steps.bru.outputs.passed }}" -ge 2
+          test "${{ steps.bru.outputs.total }}" -ge 4
           test "${{ steps.bru.outputs.duration-ms }}" -ge 0
           test "${{ steps.bru.outcome }}" = "failure"
-          test -f tests/collection/bruno-junit.xml
+          test -f "${RUNNER_TEMP}/bruno-junit.xml"
+          grep -q '<error\b' "${RUNNER_TEMP}/bruno-junit.xml"
+
+  explicit-reporter:
+    name: Explicit --reporter-junit honored, no auto-inject
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Stage fixtures + start server
+        run: |
+          mkdir -p public
+          printf '%s' '{"status":"ok"}'   > public/health.json
+          printf '%s' '{"method":"GET"}' > public/echo.json
+          nohup python3 -m http.server 8080 --directory public > server.log 2>&1 &
+          for i in {1..20}; do
+            curl -sf http://127.0.0.1:8080/health.json > /dev/null && exit 0
+            sleep 0.5
+          done
+          cat server.log; exit 1
+
+      - name: Run with explicit --reporter-junit at a known path
+        id: bru
+        uses: ./
+        with:
+          working-directory: tests/collection
+          command: 'run health.bru echo.bru --env ci --sandbox developer --reporter-junit results.xml'
+
+      - name: Assert user's path was honored and default was not created
+        run: |
+          set -euo pipefail
+          test "${{ steps.bru.outputs.exit-code }}" = "0"
+          test -f tests/collection/results.xml
+          test ! -e "${RUNNER_TEMP}/bruno-junit.xml"

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         bru-version: ['3.0.0', 'latest']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Stage fixtures for local HTTP server
         run: |
@@ -74,7 +74,7 @@ jobs:
       matrix:
         bru-version: ['3.0.0', 'latest']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Stage fixtures + start server
         run: |

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -90,6 +90,7 @@ jobs:
         continue-on-error: true
         uses: ./
         with:
+          bru-version: ${{ matrix.bru-version }}
           working-directory: tests/collection
           command: 'run --env ci --sandbox developer'
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# Bruno run outputs (defaulted when --reporter-junit is omitted)
+bruno-junit.xml
+bruno-results.*
+bruno-reports/
+
+# Node
+node_modules/
+
+# Logs and temp
+*.log
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -2,9 +2,18 @@
 
 Official GitHub Action for running [Bruno](https://www.usebruno.com) CLI commands in CI.
 
-Installs `@usebruno/cli`, runs an arbitrary `bru` command, parses the JUnit XML it emits, writes a markdown summary to the run UI, and exposes machine-readable outputs for downstream steps.
+Installs `@usebruno/cli`, runs an arbitrary `bru` command, and exposes machine-readable outputs (`exit-code`, `passed`, `failed`, `total`, `duration-ms`) for downstream steps.
 
 Design pattern follows [`postmanlabs/postman-cli-action`](https://github.com/marketplace/actions/postman-cli-action) and [`kong/setup-inso`](https://github.com/marketplace/actions/setup-inso) — installer + CWD, no flag-mirroring. Every Bruno CLI flag works the day it ships in the CLI.
+
+## Requirements
+
+GitHub-hosted runners (`ubuntu-*`, `macos-*`, `windows-*` w/ bash) ship everything the action needs.
+
+| Tool | Why | GH-hosted | Self-hosted |
+|---|---|---|---|
+| `bash` | composite scripts | ✅ | install |
+| `node` | the action installs Node 20 via `actions/setup-node@v6` | ✅ (auto) | ✅ (auto) |
 
 ## Quickstart
 
@@ -26,7 +35,7 @@ Design pattern follows [`postmanlabs/postman-cli-action`](https://github.com/mar
 | `bru-version` | no | `latest` | Version of `@usebruno/cli` to install. |
 | `working-directory` | no | `.` | Shell working directory. Typically the Bruno collection root. |
 
-No typed inputs for `--env`, `--env-var`, `--tags`, `--bail`, `--sandbox`, etc. They all go in `command`. This is deliberate: zero coordination cost when the CLI adds a flag.
+No typed inputs for `--env`, `--env-var`, `--tags`, `--bail`, `--sandbox`, `--reporter-*`, etc. They all go in `command`. This is deliberate: zero coordination cost when the CLI adds a flag.
 
 ## Outputs
 
@@ -37,12 +46,8 @@ No typed inputs for `--env`, `--env-var`, `--tags`, `--bail`, `--sandbox`, etc. 
 | `total` | Total requests executed. |
 | `duration-ms` | Sum of testsuite durations in ms. |
 | `exit-code` | Raw exit code from `bru run`. |
-| `report-html`, `report-junit`, `report-json` | Paths to the generated reports. JUnit always populated (defaulted if `command` omits `--reporter-junit`); JSON / HTML populated only when their flag appears in `command`. |
 
-### How the reporter outputs are populated
-
-- **JUnit is always emitted.** If `command` contains `--reporter-junit X.xml`, that path is used. Otherwise the action appends `--reporter-junit bruno-junit.xml` because the parser needs it for `passed` / `failed` / `total`.
-- **JSON and HTML are opt-in.** Add `--reporter-json X.json` or `--reporter-html X.html` to `command` yourself. The action detects them and exposes the absolute path as `report-json` / `report-html`. Nothing is injected silently — this is a Bruno CLI concern, not a GitHub Action concern. See the [Bruno CLI command options](https://docs.usebruno.com/bru-cli/commandOptions).
+Counts come from the JUnit XML emitted by the CLI. If `command` omits `--reporter-junit`, the action injects `--reporter-junit bruno-junit.xml` internally so the parser has something to read. JSON and HTML reporters are pure CLI pass-through — add `--reporter-json X.json` or `--reporter-html X.html` to `command` yourself if you want those files; the action does not touch their paths.
 
 ## Examples
 
@@ -91,8 +96,6 @@ Each service owns its own collection. Point `working-directory` at the per-servi
     working-directory: services/payments/bruno
     command: 'run --env ci --reporter-junit results.xml'
 ```
-
-All `report-*` outputs resolve to absolute paths, so downstream steps work regardless of where the runner cwd ends up.
 
 ### 4a. Workspace + global environment
 
@@ -149,8 +152,7 @@ strategy:
     env: [staging, prod]
 steps:
   - uses: actions/checkout@v6
-  - id: bruno
-    uses: usebruno/bruno-run-action@v1
+  - uses: usebruno/bruno-run-action@v1
     with:
       working-directory: bruno
       command: >-
@@ -163,25 +165,24 @@ steps:
     with:
       name: bruno-report-${{ matrix.env }}
       path: |
-        ${{ steps.bruno.outputs.report-junit }}
-        ${{ steps.bruno.outputs.report-html }}
+        bruno/reports/${{ matrix.env }}.xml
+        bruno/reports/${{ matrix.env }}.html
 ```
 
 ### 5. PR comments via `EnricoMi/publish-unit-test-result-action`
 
-The always-on `report-junit` output plugs straight into the most-used test-result publisher:
+Add `--reporter-junit results.xml` to your `command`, then point the publisher at the same path. `${{ github.workspace }}` makes the path absolute regardless of `working-directory`.
 
 ```yaml
 - uses: usebruno/bruno-run-action@v1
-  id: bruno
   with:
     working-directory: tests/payments
-    command: 'run --env prod'
+    command: 'run --env prod --reporter-junit results.xml'
 
 - uses: EnricoMi/publish-unit-test-result-action@v2
   if: always()
   with:
-    files: ${{ steps.bruno.outputs.report-junit }}
+    files: ${{ github.workspace }}/tests/payments/results.xml
 ```
 
 ### 6. Conditional Slack on regression
@@ -196,35 +197,9 @@ The always-on `report-junit` output plugs straight into the most-used test-resul
 
 - if: steps.bruno.outputs.failed != '0'
   run: ./scripts/slack-notify.sh "${{ steps.bruno.outputs.failed }} failing"
-```
 
-## PR annotations
-
-Every failing request emits a GitHub `::error::` annotation. Failures show up in three places without expanding the run log:
-
-- **Files Changed tab** of the PR — a red ❌ marker on the `.bru` file with the assertion message inline.
-- **Workflow run page** — a banner at the top listing each failed request, its location, and the message.
-- **Checks tab** — `Bruno Run · N annotations · failed`.
-
-Format emitted to stdout (parsed by GitHub):
-```
-::error file=bruno/auth/login.bru,title=auth/login::Expected status 200 but got 401
-```
-
-Always on, no toggle. Matches the Newman ecosystem's default.
-
-## Step summary
-
-Every run writes a markdown table to `$GITHUB_STEP_SUMMARY`, parsed from the JUnit XML:
-
-```
-| Request               | Status | Duration |
-|-----------------------|--------|----------|
-| auth / login          | ✅     | 142 ms   |
-| users / list          | ✅     | 89 ms    |
-| users / create        | ❌     | 250 ms   |
-
-**Total: 2 passed, 1 failed, 0 skipped (of 3) — 481 ms**
+- if: steps.bruno.outputs.duration-ms > 30000
+  run: ./scripts/slack-notify.sh "Bruno took ${{ steps.bruno.outputs.duration-ms }} ms"
 ```
 
 ## Versioning
@@ -236,29 +211,15 @@ Every run writes a markdown table to `$GITHUB_STEP_SUMMARY`, parsed from the JUn
 
 The `v<major>` tag is retagged automatically on every published release.
 
-## Migrating from `matt-ball/newman-action` or `postmanlabs/postman-cli-action`
-
-| Postman input | Bruno equivalent |
-|---|---|
-| `command: 'collection run X.json'` | `command: 'run'` + `working-directory: X` |
-| `api-key` | not applicable (Bruno is local-only) |
-| `region` | not applicable |
-| `postman-cli-version` | `bru-version` |
-| `working-directory` | `working-directory` |
-
-CLI flag translation is out of scope for this README — see [Bruno CLI command options](https://docs.usebruno.com/bru-cli/commandOptions).
-
 ## Troubleshooting
 
-**Sandbox migration (Bruno CLI v3+).** v3 changed the default sandbox. If your tests relied on Node built-ins (`require`, `Buffer`, etc.), add `--sandbox developer` to `command`:
+**Sandbox migration (Bruno CLI v3+).** v3 changed the default sandbox. If your tests rely on Node built-ins (`require`, `Buffer`, etc.), add `--sandbox developer` to `command`:
 
 ```yaml
 command: 'run --env ci --sandbox developer'
 ```
 
-**`exit-code` is non-zero but `failed` is `0`.** The `bru` process crashed before writing JUnit, or wrote an empty report. Treat as a runtime error — check the step log for stderr. See the exit-code reference below for the specific code.
-
-**I only see `report-junit` set, not `report-json` or `report-html`.** That's expected. JUnit is the only reporter the action emits by default (the parser needs it). Add `--reporter-json X.json` and/or `--reporter-html X.html` to `command` yourself if you want those files. The action detects whatever flags you set and exposes the absolute paths.
+**`exit-code` is non-zero but `failed` is `0`.** The `bru` process crashed before writing JUnit, or wrote an empty report. Treat as a runtime error — check the step log for stderr. See the exit-code reference below.
 
 ### Exit-code reference
 
@@ -267,7 +228,7 @@ command: 'run --env ci --sandbox developer'
 | Code | Meaning | Common cause |
 |------|---------|--------------|
 | 0    | All requests, tests, and assertions passed | — |
-| 1    | One or more requests, tests, or assertions failed | inspect `report-junit`; fix the failing tests |
+| 1    | One or more requests, tests, or assertions failed | inspect the JUnit XML; fix the failing tests |
 | 2    | Reporter output directory does not exist | create the dir or change `--reporter-junit` path |
 | 3    | Request chain caused an infinite loop | break the loop in your collection |
 | 4    | `bru` was invoked outside a collection root | set `working-directory` to the collection dir |
@@ -286,7 +247,7 @@ command: 'run --env ci --sandbox developer'
 
 (Source: `packages/bruno-cli/src/constants.js` in the Bruno repo. Codes may shift across major CLI versions; the nightly smoke catches changes.)
 
-### My job failed before the summary appeared
+### My job failed before bru could run
 
 If the run log shows a red **Install Bruno CLI** step (not **Run bru**), the failure is in `npm install -g @usebruno/cli`, not in your collection. `outputs.exit-code` will be empty because `bru` never ran. Expand that step and look for one of:
 
@@ -300,15 +261,7 @@ If the run log shows a red **Install Bruno CLI** step (not **Run bru**), the fai
 
 All of these surface npm exit `1`. The useful signal is the stderr text, not the exit number.
 
-**JUnit XML not found.** Same as above. The step summary will say so explicitly.
-
-**Self-hosted runners.** The action installs Node 20 via `actions/setup-node@v6` — no additional install needed. `jq` is **not** required (parsing is pure Node).
-
 **Network timeouts.** Bruno honours `HTTP_PROXY` / `HTTPS_PROXY` / `NO_PROXY`. Set them via `env:` on the step.
-
-## Supported Bruno CLI versions
-
-Tested on every PR via matrix smoke (`3.0.0` floor and `latest`). Nightly run against `@usebruno/cli@latest` catches CLI regressions before users hit them.
 
 ## Other CI platforms
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Design pattern follows [`postmanlabs/postman-cli-action`](https://github.com/mar
 ## Quickstart
 
 ```yaml
-- uses: actions/checkout@v4
+- uses: actions/checkout@v6
 - uses: usebruno/bruno-run-action@v1
   with:
     working-directory: tests/payments
@@ -49,7 +49,7 @@ No typed inputs for `--env`, `--env-var`, `--tags`, `--bail`, `--sandbox`, etc. 
 ### 1. Canonical pattern
 
 ```yaml
-- uses: actions/checkout@v4
+- uses: actions/checkout@v6
 - uses: usebruno/bruno-run-action@v1
   with:
     working-directory: tests/payments
@@ -73,7 +73,7 @@ strategy:
   matrix:
     env: [staging, prod]
 steps:
-  - uses: actions/checkout@v4
+  - uses: actions/checkout@v6
   - uses: usebruno/bruno-run-action@v1
     with:
       working-directory: tests/payments
@@ -85,7 +85,7 @@ steps:
 Each service owns its own collection. Point `working-directory` at the per-service collection root:
 
 ```yaml
-- uses: actions/checkout@v4
+- uses: actions/checkout@v6
 - uses: usebruno/bruno-run-action@v1
   with:
     working-directory: services/payments/bruno
@@ -99,7 +99,7 @@ All `report-*` outputs resolve to absolute paths, so downstream steps work regar
 For collections that live inside a workspace (`workspace.yml` at the root and the collection in a subfolder):
 
 ```yaml
-- uses: actions/checkout@v4
+- uses: actions/checkout@v6
 - uses: usebruno/bruno-run-action@v1
   with:
     working-directory: .
@@ -120,7 +120,7 @@ The YAML `>-` folded scalar keeps the command readable across lines while stayin
 Run the smoke tags on every PR; run everything on `main`:
 
 ```yaml
-- uses: actions/checkout@v4
+- uses: actions/checkout@v6
 - uses: usebruno/bruno-run-action@v1
   with:
     working-directory: bruno
@@ -133,7 +133,7 @@ Run the smoke tags on every PR; run everything on `main`:
 ### 4c. Data-driven run via CSV
 
 ```yaml
-- uses: actions/checkout@v4
+- uses: actions/checkout@v6
 - uses: usebruno/bruno-run-action@v1
   with:
     working-directory: bruno
@@ -148,7 +148,7 @@ strategy:
   matrix:
     env: [staging, prod]
 steps:
-  - uses: actions/checkout@v4
+  - uses: actions/checkout@v6
   - id: bruno
     uses: usebruno/bruno-run-action@v1
     with:
@@ -159,7 +159,7 @@ steps:
         --reporter-html  reports/${{ matrix.env }}.html
 
   - if: always()
-    uses: actions/upload-artifact@v4
+    uses: actions/upload-artifact@v7
     with:
       name: bruno-report-${{ matrix.env }}
       path: |
@@ -302,7 +302,7 @@ All of these surface npm exit `1`. The useful signal is the stderr text, not the
 
 **JUnit XML not found.** Same as above. The step summary will say so explicitly.
 
-**Self-hosted runners.** The action installs Node 20 via `actions/setup-node@v4` — no additional install needed. `jq` is **not** required (parsing is pure Node).
+**Self-hosted runners.** The action installs Node 20 via `actions/setup-node@v6` — no additional install needed. `jq` is **not** required (parsing is pure Node).
 
 **Network timeouts.** Bruno honours `HTTP_PROXY` / `HTTPS_PROXY` / `NO_PROXY`. Set them via `env:` on the step.
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,319 @@
+# Bruno Run Action
+
+Official GitHub Action for running [Bruno](https://www.usebruno.com) CLI commands in CI.
+
+Installs `@usebruno/cli`, runs an arbitrary `bru` command, parses the JUnit XML it emits, writes a markdown summary to the run UI, and exposes machine-readable outputs for downstream steps.
+
+Design pattern follows [`postmanlabs/postman-cli-action`](https://github.com/marketplace/actions/postman-cli-action) and [`kong/setup-inso`](https://github.com/marketplace/actions/setup-inso) — installer + CWD, no flag-mirroring. Every Bruno CLI flag works the day it ships in the CLI.
+
+## Quickstart
+
+```yaml
+- uses: actions/checkout@v4
+- uses: usebruno/bruno-run-action@v1
+  with:
+    working-directory: tests/payments
+    command: 'run --env prod --reporter-junit results.xml'
+```
+
+`working-directory` is the Bruno collection root. `command` is everything after `bru` — the action prepends it.
+
+## Inputs
+
+| Input | Required | Default | Description |
+|---|---|---|---|
+| `command` | yes | — | The `bru` subcommand and flags (e.g. `run --env prod --reporter-junit results.xml`). The action prepends `bru`. |
+| `bru-version` | no | `latest` | Version of `@usebruno/cli` to install. |
+| `working-directory` | no | `.` | Shell working directory. Typically the Bruno collection root. |
+
+No typed inputs for `--env`, `--env-var`, `--tags`, `--bail`, `--sandbox`, etc. They all go in `command`. This is deliberate: zero coordination cost when the CLI adds a flag.
+
+## Outputs
+
+| Output | Description |
+|---|---|
+| `passed` | Number of requests that passed. |
+| `failed` | Number of requests that failed. |
+| `total` | Total requests executed. |
+| `duration-ms` | Sum of testsuite durations in ms. |
+| `exit-code` | Raw exit code from `bru run`. |
+| `report-html`, `report-junit`, `report-json` | Paths to the generated reports. JUnit always populated (defaulted if `command` omits `--reporter-junit`); JSON / HTML populated only when their flag appears in `command`. |
+
+### How the reporter outputs are populated
+
+- **JUnit is always emitted.** If `command` contains `--reporter-junit X.xml`, that path is used. Otherwise the action appends `--reporter-junit bruno-junit.xml` because the parser needs it for `passed` / `failed` / `total`.
+- **JSON and HTML are opt-in.** Add `--reporter-json X.json` or `--reporter-html X.html` to `command` yourself. The action detects them and exposes the absolute path as `report-json` / `report-html`. Nothing is injected silently — this is a Bruno CLI concern, not a GitHub Action concern. See the [Bruno CLI command options](https://docs.usebruno.com/bru-cli/commandOptions).
+
+## Examples
+
+### 1. Canonical pattern
+
+```yaml
+- uses: actions/checkout@v4
+- uses: usebruno/bruno-run-action@v1
+  with:
+    working-directory: tests/payments
+    command: 'run --env prod --reporter-junit results.xml'
+```
+
+### 2. Run a sub-folder
+
+```yaml
+- uses: usebruno/bruno-run-action@v1
+  with:
+    working-directory: tests/payments
+    command: 'run smoke --env prod'
+```
+
+### 3. Matrix across environments
+
+```yaml
+strategy:
+  fail-fast: false
+  matrix:
+    env: [staging, prod]
+steps:
+  - uses: actions/checkout@v4
+  - uses: usebruno/bruno-run-action@v1
+    with:
+      working-directory: tests/payments
+      command: 'run --env ${{ matrix.env }} --reporter-junit ${{ matrix.env }}.xml'
+```
+
+### 4. Monorepo
+
+Each service owns its own collection. Point `working-directory` at the per-service collection root:
+
+```yaml
+- uses: actions/checkout@v4
+- uses: usebruno/bruno-run-action@v1
+  with:
+    working-directory: services/payments/bruno
+    command: 'run --env ci --reporter-junit results.xml'
+```
+
+All `report-*` outputs resolve to absolute paths, so downstream steps work regardless of where the runner cwd ends up.
+
+### 4a. Workspace + global environment
+
+For collections that live inside a workspace (`workspace.yml` at the root and the collection in a subfolder):
+
+```yaml
+- uses: actions/checkout@v4
+- uses: usebruno/bruno-run-action@v1
+  with:
+    working-directory: .
+    command: >-
+      run collections/payments-api
+      --workspace-path .
+      --global-env ci
+      --tags smoke,workflow,release-gate
+      --env-var "platform_name=GitHub Actions"
+      --env-var "build_id=${{ github.run_id }}"
+      --env-var "commit_sha=${{ github.sha }}"
+```
+
+The YAML `>-` folded scalar keeps the command readable across lines while staying a single string for the action to parse.
+
+### 4b. Different test sets per trigger
+
+Run the smoke tags on every PR; run everything on `main`:
+
+```yaml
+- uses: actions/checkout@v4
+- uses: usebruno/bruno-run-action@v1
+  with:
+    working-directory: bruno
+    command: >-
+      run
+      --env ci
+      ${{ github.event_name == 'pull_request' && '--tags smoke' || '' }}
+```
+
+### 4c. Data-driven run via CSV
+
+```yaml
+- uses: actions/checkout@v4
+- uses: usebruno/bruno-run-action@v1
+  with:
+    working-directory: bruno
+    command: 'run --env ci --csv-file-path tests/users.csv'
+```
+
+### 4d. Per-matrix-leg artifact (HTML + JUnit)
+
+```yaml
+strategy:
+  fail-fast: false
+  matrix:
+    env: [staging, prod]
+steps:
+  - uses: actions/checkout@v4
+  - id: bruno
+    uses: usebruno/bruno-run-action@v1
+    with:
+      working-directory: bruno
+      command: >-
+        run --env ${{ matrix.env }}
+        --reporter-junit reports/${{ matrix.env }}.xml
+        --reporter-html  reports/${{ matrix.env }}.html
+
+  - if: always()
+    uses: actions/upload-artifact@v4
+    with:
+      name: bruno-report-${{ matrix.env }}
+      path: |
+        ${{ steps.bruno.outputs.report-junit }}
+        ${{ steps.bruno.outputs.report-html }}
+```
+
+### 5. PR comments via `EnricoMi/publish-unit-test-result-action`
+
+The always-on `report-junit` output plugs straight into the most-used test-result publisher:
+
+```yaml
+- uses: usebruno/bruno-run-action@v1
+  id: bruno
+  with:
+    working-directory: tests/payments
+    command: 'run --env prod'
+
+- uses: EnricoMi/publish-unit-test-result-action@v2
+  if: always()
+  with:
+    files: ${{ steps.bruno.outputs.report-junit }}
+```
+
+### 6. Conditional Slack on regression
+
+```yaml
+- uses: usebruno/bruno-run-action@v1
+  id: bruno
+  continue-on-error: true
+  with:
+    working-directory: tests/payments
+    command: 'run --env prod'
+
+- if: steps.bruno.outputs.failed != '0'
+  run: ./scripts/slack-notify.sh "${{ steps.bruno.outputs.failed }} failing"
+```
+
+## PR annotations
+
+Every failing request emits a GitHub `::error::` annotation. Failures show up in three places without expanding the run log:
+
+- **Files Changed tab** of the PR — a red ❌ marker on the `.bru` file with the assertion message inline.
+- **Workflow run page** — a banner at the top listing each failed request, its location, and the message.
+- **Checks tab** — `Bruno Run · N annotations · failed`.
+
+Format emitted to stdout (parsed by GitHub):
+```
+::error file=bruno/auth/login.bru,title=auth/login::Expected status 200 but got 401
+```
+
+Always on, no toggle. Matches the Newman ecosystem's default.
+
+## Step summary
+
+Every run writes a markdown table to `$GITHUB_STEP_SUMMARY`, parsed from the JUnit XML:
+
+```
+| Request               | Status | Duration |
+|-----------------------|--------|----------|
+| auth / login          | ✅     | 142 ms   |
+| users / list          | ✅     | 89 ms    |
+| users / create        | ❌     | 250 ms   |
+
+**Total: 2 passed, 1 failed, 0 skipped (of 3) — 481 ms**
+```
+
+## Versioning
+
+| Tag | Behaviour |
+|---|---|
+| `@v1` | Floating major. Receives every backwards-compatible release. |
+| `@v1.2.3` | Immutable. Pinned to a specific release. |
+
+The `v<major>` tag is retagged automatically on every published release.
+
+## Migrating from `matt-ball/newman-action` or `postmanlabs/postman-cli-action`
+
+| Postman input | Bruno equivalent |
+|---|---|
+| `command: 'collection run X.json'` | `command: 'run'` + `working-directory: X` |
+| `api-key` | not applicable (Bruno is local-only) |
+| `region` | not applicable |
+| `postman-cli-version` | `bru-version` |
+| `working-directory` | `working-directory` |
+
+CLI flag translation is out of scope for this README — see [Bruno CLI command options](https://docs.usebruno.com/bru-cli/commandOptions).
+
+## Troubleshooting
+
+**Sandbox migration (Bruno CLI v3+).** v3 changed the default sandbox. If your tests relied on Node built-ins (`require`, `Buffer`, etc.), add `--sandbox developer` to `command`:
+
+```yaml
+command: 'run --env ci --sandbox developer'
+```
+
+**`exit-code` is non-zero but `failed` is `0`.** The `bru` process crashed before writing JUnit, or wrote an empty report. Treat as a runtime error — check the step log for stderr. See the exit-code reference below for the specific code.
+
+**I only see `report-junit` set, not `report-json` or `report-html`.** That's expected. JUnit is the only reporter the action emits by default (the parser needs it). Add `--reporter-json X.json` and/or `--reporter-html X.html` to `command` yourself if you want those files. The action detects whatever flags you set and exposes the absolute paths.
+
+### Exit-code reference
+
+`bru` exits with one of the following codes. They flow through to `steps.<id>.outputs.exit-code`:
+
+| Code | Meaning | Common cause |
+|------|---------|--------------|
+| 0    | All requests, tests, and assertions passed | — |
+| 1    | One or more requests, tests, or assertions failed | inspect `report-junit`; fix the failing tests |
+| 2    | Reporter output directory does not exist | create the dir or change `--reporter-junit` path |
+| 3    | Request chain caused an infinite loop | break the loop in your collection |
+| 4    | `bru` was invoked outside a collection root | set `working-directory` to the collection dir |
+| 5    | A file referenced by `command` was not found | typo'd path in `command` |
+| 6    | Environment file not found | check `environments/<env>.bru` exists |
+| 7    | `--env-var` value not parsable as `name=value` | fix the quoting in `command` |
+| 8    | `--env-var` format incorrect | same — see Bruno CLI docs |
+| 9    | Invalid reporter format | only `json` / `junit` / `html` accepted |
+| 10   | Failed to parse a `.bru` / env / config file | syntax error in the file |
+| 11   | Workspace not found (when `--workspace-path` used) | check the path |
+| 12   | `--global-env` used without `--workspace-path` | add `--workspace-path` |
+| 13   | Global environment file not found | check the global env name |
+| 137  | OS killed the process (`SIGKILL`, usually OOM) | bigger runner or split the collection |
+| 130  | Job was cancelled (`SIGINT`) | check `timeout-minutes`; nothing to fix in `command` |
+| 255  | Unhandled CLI crash (`ERROR_GENERIC`) | open an issue in `usebruno/bruno` with the stderr |
+
+(Source: `packages/bruno-cli/src/constants.js` in the Bruno repo. Codes may shift across major CLI versions; the nightly smoke catches changes.)
+
+### My job failed before the summary appeared
+
+If the run log shows a red **Install Bruno CLI** step (not **Run bru**), the failure is in `npm install -g @usebruno/cli`, not in your collection. `outputs.exit-code` will be empty because `bru` never ran. Expand that step and look for one of:
+
+| stderr substring | Likely cause | Fix |
+|---|---|---|
+| `E404` / `404 Not Found` | `bru-version` doesn't exist on npm | pick a real version (or `latest`) |
+| `ENOTFOUND` / `ETIMEDOUT` | runner can't reach `registry.npmjs.org` | check corp proxy / network policy |
+| `EACCES` | self-hosted runner missing install permission | adjust npm prefix or run with sudo |
+| `ENOSPC` | self-hosted runner disk full | clear space |
+| `EINTEGRITY` | corrupted npm cache | `npm cache clean --force` then re-run |
+
+All of these surface npm exit `1`. The useful signal is the stderr text, not the exit number.
+
+**JUnit XML not found.** Same as above. The step summary will say so explicitly.
+
+**Self-hosted runners.** The action installs Node 20 via `actions/setup-node@v4` — no additional install needed. `jq` is **not** required (parsing is pure Node).
+
+**Network timeouts.** Bruno honours `HTTP_PROXY` / `HTTPS_PROXY` / `NO_PROXY`. Set them via `env:` on the step.
+
+## Supported Bruno CLI versions
+
+Tested on every PR via matrix smoke (`3.0.0` floor and `latest`). Nightly run against `@usebruno/cli@latest` catches CLI regressions before users hit them.
+
+## Other CI platforms
+
+For GitLab, Azure DevOps, Jenkins, CircleCI — use the [Bruno CLI Docker image](https://hub.docker.com/r/usebruno/cli) directly. This action is GitHub-Actions-specific by design.
+
+## License
+
+MIT

--- a/README.md
+++ b/README.md
@@ -426,7 +426,7 @@ command: 'run --env ci --sandbox developer'
 | 130  | Job was cancelled (`SIGINT`) | check `timeout-minutes`; nothing to fix in `command` |
 | 255  | Unhandled CLI crash (`ERROR_GENERIC`) | open an issue in `usebruno/bruno` with the stderr |
 
-(Source: `packages/bruno-cli/src/constants.js` in the Bruno repo. Codes may shift across major CLI versions; the nightly smoke catches changes.)
+(Source: `packages/bruno-cli/src/constants.js` in the Bruno repo. Codes may shift across major CLI versions; the nightly workflow catches changes.)
 
 ### Job failed before bru could run
 

--- a/README.md
+++ b/README.md
@@ -1,177 +1,168 @@
-# Bruno Run Action
+# Bruno CLI GitHub Action
 
 Official GitHub Action for running [Bruno](https://www.usebruno.com) CLI commands in CI.
 
-Installs `@usebruno/cli`, runs an arbitrary `bru` command, and exposes machine-readable outputs (`exit-code`, `passed`, `failed`, `total`, `duration-ms`) for downstream steps.
+Installs `@usebruno/cli`, runs an arbitrary `bru` command, parses the emitted JUnit XML, and exposes machine-readable counts (`exit-code`, `passed`, `failed`, `total`, `duration-ms`) for downstream steps. UI rendering, artifact upload, PR comments, and soft-fail semantics are delegated to the GitHub Actions ecosystem (`EnricoMi/publish-unit-test-result-action`, `dorny/test-reporter`, `actions/upload-artifact`, `continue-on-error`). See [Pairing with downstream actions](#pairing-with-downstream-actions) for canonical recipes.
 
-Design pattern follows [`postmanlabs/postman-cli-action`](https://github.com/marketplace/actions/postman-cli-action) and [`kong/setup-inso`](https://github.com/marketplace/actions/setup-inso) — installer + CWD, no flag-mirroring. Every Bruno CLI flag works the day it ships in the CLI.
-
-## Requirements
-
-GitHub-hosted runners (`ubuntu-*`, `macos-*`, `windows-*` w/ bash) ship everything the action needs.
-
-| Tool | Why | GH-hosted | Self-hosted |
-|---|---|---|---|
-| `bash` | composite scripts | ✅ | install |
-| `node` | the action installs Node 20 via `actions/setup-node@v6` | ✅ (auto) | ✅ (auto) |
+Design pattern follows [`postmanlabs/postman-cli-action`](https://github.com/postmanlabs/postman-cli-action) and [`kong/setup-inso`](https://github.com/kong/setup-inso): minimal-input pass-through, no flag mirroring.
 
 ## Quickstart
 
 ```yaml
-- uses: actions/checkout@v6
+# Minimal — installs the CLI, runs the collection, returns counts as outputs.
+# Step fails (red) on assertion failure, succeeds (green) on success.
+# No UI surfaces, no artifact upload by default.
+# See "Pairing with downstream actions" for PR comments, annotations,
+# Step Summary, artifact upload, soft-fail, and more.
 - uses: usebruno/bruno-run-action@v1
   with:
     working-directory: tests/payments
-    command: 'run --env prod --reporter-junit results.xml'
+    command: 'run --env prod'
 ```
 
-`working-directory` is the Bruno collection root. `command` is everything after `bru` — the action prepends it.
+**What you'll see:** the workflow step turns red on assertion failure (green on success). No PR comments, no annotations, no Step Summary, no uploaded artifact. Outputs are populated for downstream conditional steps.
 
 ## Inputs
 
 | Input | Required | Default | Description |
 |---|---|---|---|
-| `command` | yes | — | The `bru` subcommand and flags (e.g. `run --env prod --reporter-junit results.xml`). The action prepends `bru`. |
+| `command` | yes | — | The `bru` subcommand and flags (e.g. `run --env prod`). The action prepends `bru`. Reporter flags are optional; `--reporter-junit` is auto-injected if absent. |
 | `bru-version` | no | `latest` | Version of `@usebruno/cli` to install. |
 | `working-directory` | no | `.` | Shell working directory. Typically the Bruno collection root. |
 
-No typed inputs for `--env`, `--env-var`, `--tags`, `--bail`, `--sandbox`, `--reporter-*`, etc. They all go in `command`. This is deliberate: zero coordination cost when the CLI adds a flag.
+No typed inputs for `--env`, `--env-var`, `--tags`, `--bail`, `--sandbox`, `--reporter-*`, etc. They all go in `command`. Every CLI flag works the day it ships in the CLI, with zero coordination cost.
 
 ## Outputs
 
+Available as `${{ steps.<id>.outputs.<name> }}` in subsequent steps:
+
 | Output | Description |
 |---|---|
-| `passed` | Number of requests that passed. |
-| `failed` | Number of requests that failed. |
-| `total` | Total requests executed. |
-| `duration-ms` | Sum of testsuite durations in ms. |
-| `exit-code` | Raw exit code from `bru run`. |
+| `exit-code` | The `bru` process exit code. |
+| `passed` | Number of passed requests. |
+| `failed` | Number of failed requests (assertion failures or runtime errors). |
+| `total` | Total requests run. |
+| `duration-ms` | Total run duration in milliseconds. |
 
-Counts come from the JUnit XML emitted by the CLI. If `command` omits `--reporter-junit`, the action injects `--reporter-junit bruno-junit.xml` internally so the parser has something to read. JSON and HTML reporters are pure CLI pass-through — add `--reporter-json X.json` or `--reporter-html X.html` to `command` yourself if you want those files; the action does not touch their paths.
+Report file paths are intentionally **not** outputs. Users who chain to downstream actions pass an explicit `--reporter-junit <path>` in `command` and reference that path directly in the next step.
 
-## Examples
+## Behavior
 
-### 1. Canonical pattern
+### JUnit auto-injection (always-on)
+
+If the user's `command` does not contain `--reporter-junit`, the action appends `--reporter-junit "$RUNNER_TEMP/bruno-junit.xml"` before invoking `bru`. JUnit is required for output extraction; auto-injection means a minimal `command: 'run'` produces count outputs without the user having to remember reporter flags. The file lives in the runner's temp dir and is auto-cleaned post-job.
+
+If the user explicitly passes `--reporter-junit some/path.xml`, the action honors that path and parses from there.
+
+### Exit code propagation
+
+The action propagates `bru`'s exit code naturally. The workflow step succeeds on exit 0 and fails on non-zero. Users who want the workflow to continue past failures use GitHub Actions' built-in `continue-on-error: true` (see recipe #12).
+
+## Pairing with downstream actions
+
+This section covers every reporting and artifact use case. The action emits clean JUnit XML; downstream actions render it for the user-visible surface needed or upload it as a workflow artifact.
+
+### 1. PR comment on every run (sticky, updated in place)
+
+The most common ask. `EnricoMi/publish-unit-test-result-action` posts a single comment per PR with structured results, updated on re-runs. Adds a check run with rich annotations as a side benefit.
 
 ```yaml
-- uses: actions/checkout@v6
+name: API Tests
+on: [pull_request]
+
+permissions:
+  pull-requests: write
+  checks: write
+  contents: read
+
+jobs:
+  bruno:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: usebruno/bruno-run-action@v1
+        with:
+          working-directory: tests/payments
+          command: 'run --env prod --reporter-junit results.xml'
+
+      - uses: EnricoMi/publish-unit-test-result-action@v2
+        if: always()
+        with:
+          files: tests/payments/results.xml
+```
+
+**Prerequisites:** `pull-requests: write` and `checks: write` permissions in the workflow file.
+**What you'll see:** a single Bruno-themed comment in the PR Conversation tab that updates in place on every re-run, plus a check run with structured per-test results in the PR Checks tab.
+**Why `if: always()`:** EnricoMi must run even when the Bruno step fails the build, otherwise users do not see the comment on failure.
+
+### 2. PR comment only when there are failures
+
+For teams who do not want a green-passes-everywhere comment polluting the conversation:
+
+```yaml
+- uses: EnricoMi/publish-unit-test-result-action@v2
+  if: always()
+  with:
+    files: tests/payments/results.xml
+    comment_mode: failures   # post a comment only when something failed
+```
+
+**What you'll see:** PR comment appears only when at least one assertion failed. Successful runs leave no comment behind.
+**Other `comment_mode` values:** `always` (default), `failures`, `errors`, `off`.
+
+### 3. Step Summary on the workflow run page (without PR comment)
+
+EnricoMi writes a Step Summary by default. If you want the workflow-page digest but no PR comment noise:
+
+```yaml
+- uses: EnricoMi/publish-unit-test-result-action@v2
+  if: always()
+  with:
+    files: tests/payments/results.xml
+    comment_mode: off              # disable PR comment
+    job_summary: true              # default true; shown for clarity
+```
+
+**What you'll see:** a markdown summary on the workflow run page (visible by clicking into the run from the Actions tab). No PR Conversation comment, no Checks-tab check run annotations.
+
+### 4. Workflow-level annotations (errors visible on the PR Checks card)
+
+EnricoMi posts annotations via the Check Runs API. These appear in the PR Checks tab attached to EnricoMi's check run:
+
+```yaml
+- uses: EnricoMi/publish-unit-test-result-action@v2
+  if: always()
+  with:
+    files: tests/payments/results.xml
+    report_individual_runs: true   # one annotation per failed test
+```
+
+**What you'll see:** the PR Checks tab shows the EnricoMi check run with one annotation per failed assertion, expandable for failure details.
+**Note:** line-anchored annotations on `.bru` source lines would require the CLI to emit `file=` and `line=` in JUnit. Not currently planned.
+
+### 5. Checks tab UI via dorny/test-reporter
+
+If you have a polyglot test stack (Jest, Pytest, Bruno) and want all results in the same Checks tab UI, dorny is the better tool than EnricoMi:
+
+```yaml
 - uses: usebruno/bruno-run-action@v1
   with:
     working-directory: tests/payments
     command: 'run --env prod --reporter-junit results.xml'
-```
 
-### 2. Run a sub-folder
-
-```yaml
-- uses: usebruno/bruno-run-action@v1
+- uses: dorny/test-reporter@v1
+  if: always()
   with:
-    working-directory: tests/payments
-    command: 'run smoke --env prod'
+    name: Bruno API tests
+    path: tests/payments/results.xml
+    reporter: java-junit
 ```
 
-### 3. Matrix across environments
+**What you'll see:** a separate check run in the PR Checks tab labeled "Bruno API tests" with structured per-test results and expandable failure details. Visually consistent with check runs from your other JUnit-emitting test suites.
 
-```yaml
-strategy:
-  fail-fast: false
-  matrix:
-    env: [staging, prod]
-steps:
-  - uses: actions/checkout@v6
-  - uses: usebruno/bruno-run-action@v1
-    with:
-      working-directory: tests/payments
-      command: 'run --env ${{ matrix.env }} --reporter-junit ${{ matrix.env }}.xml'
-```
+### 6. EnricoMi + dorny together (PR comment + rich Checks tab)
 
-### 4. Monorepo
-
-Each service owns its own collection. Point `working-directory` at the per-service collection root:
-
-```yaml
-- uses: actions/checkout@v6
-- uses: usebruno/bruno-run-action@v1
-  with:
-    working-directory: services/payments/bruno
-    command: 'run --env ci --reporter-junit results.xml'
-```
-
-### 4a. Workspace + global environment
-
-For collections that live inside a workspace (`workspace.yml` at the root and the collection in a subfolder):
-
-```yaml
-- uses: actions/checkout@v6
-- uses: usebruno/bruno-run-action@v1
-  with:
-    working-directory: .
-    command: >-
-      run collections/payments-api
-      --workspace-path .
-      --global-env ci
-      --tags smoke,workflow,release-gate
-      --env-var "platform_name=GitHub Actions"
-      --env-var "build_id=${{ github.run_id }}"
-      --env-var "commit_sha=${{ github.sha }}"
-```
-
-The YAML `>-` folded scalar keeps the command readable across lines while staying a single string for the action to parse.
-
-### 4b. Different test sets per trigger
-
-Run the smoke tags on every PR; run everything on `main`:
-
-```yaml
-- uses: actions/checkout@v6
-- uses: usebruno/bruno-run-action@v1
-  with:
-    working-directory: bruno
-    command: >-
-      run
-      --env ci
-      ${{ github.event_name == 'pull_request' && '--tags smoke' || '' }}
-```
-
-### 4c. Data-driven run via CSV
-
-```yaml
-- uses: actions/checkout@v6
-- uses: usebruno/bruno-run-action@v1
-  with:
-    working-directory: bruno
-    command: 'run --env ci --csv-file-path tests/users.csv'
-```
-
-### 4d. Per-matrix-leg artifact (HTML + JUnit)
-
-```yaml
-strategy:
-  fail-fast: false
-  matrix:
-    env: [staging, prod]
-steps:
-  - uses: actions/checkout@v6
-  - uses: usebruno/bruno-run-action@v1
-    with:
-      working-directory: bruno
-      command: >-
-        run --env ${{ matrix.env }}
-        --reporter-junit reports/${{ matrix.env }}.xml
-        --reporter-html  reports/${{ matrix.env }}.html
-
-  - if: always()
-    uses: actions/upload-artifact@v7
-    with:
-      name: bruno-report-${{ matrix.env }}
-      path: |
-        bruno/reports/${{ matrix.env }}.xml
-        bruno/reports/${{ matrix.env }}.html
-```
-
-### 5. PR comments via `EnricoMi/publish-unit-test-result-action`
-
-Add `--reporter-junit results.xml` to your `command`, then point the publisher at the same path. `${{ github.workspace }}` makes the path absolute regardless of `working-directory`.
+When you want both: a PR Conversation comment from EnricoMi and a polished Checks tab UI from dorny:
 
 ```yaml
 - uses: usebruno/bruno-run-action@v1
@@ -182,25 +173,213 @@ Add `--reporter-junit results.xml` to your `command`, then point the publisher a
 - uses: EnricoMi/publish-unit-test-result-action@v2
   if: always()
   with:
-    files: ${{ github.workspace }}/tests/payments/results.xml
+    files: tests/payments/results.xml
+    comment_mode: always
+
+- uses: dorny/test-reporter@v1
+  if: always()
+  with:
+    name: Bruno API tests
+    path: tests/payments/results.xml
+    reporter: java-junit
 ```
 
-### 6. Conditional Slack on regression
+**What you'll see:** PR Conversation gets the EnricoMi sticky comment; PR Checks tab shows two check runs (one from each downstream action) plus the EnricoMi annotations.
+
+### 7. Artifact upload with header sanitization
+
+Bruno's CLI handles sensitive-header redaction; pass the flag in `command`. Chain `actions/upload-artifact@v7` to persist the report:
 
 ```yaml
 - uses: usebruno/bruno-run-action@v1
-  id: bruno
+  with:
+    working-directory: tests/payments
+    command: 'run --env prod --reporter-junit results.xml --reporter-skip-headers "Authorization Cookie X-Tenant-Token"'
+
+- uses: actions/upload-artifact@v7
+  if: always()
+  with:
+    name: bruno-report-${{ github.run_id }}-${{ github.job }}
+    path: tests/payments/results.xml
+```
+
+**What you'll see:** an artifact named `bruno-report-<run_id>-<job>` on the workflow run page, downloadable for 90 days (GitHub default retention). `Authorization`, `Cookie`, and `X-Tenant-Token` headers are redacted in the JUnit XML before upload.
+
+To customize retention or use compression options, see `actions/upload-artifact@v7`'s own inputs (`retention-days`, `compression-level`, `if-no-files-found`).
+
+### 8. Multiple report formats (JUnit + HTML + JSON)
+
+Pass multiple reporter flags in `command`. Chain `actions/upload-artifact@v7` with a path list:
+
+```yaml
+- uses: usebruno/bruno-run-action@v1
+  with:
+    working-directory: tests/payments
+    command: 'run --env prod --reporter-junit results.xml --reporter-html report.html --reporter-json report.json'
+
+- uses: actions/upload-artifact@v7
+  if: always()
+  with:
+    name: bruno-reports-${{ github.run_id }}
+    path: |
+      tests/payments/results.xml
+      tests/payments/report.html
+      tests/payments/report.json
+```
+
+**What you'll see:** an artifact containing all three report files. Download to a browser to view the rich HTML report; JSON is consumable by custom dashboards or aggregators.
+
+### 9. Slack notification on failure
+
+Use the JUnit-derived `failed` output as a conditional. Use `continue-on-error: true` so the notification step still runs:
+
+```yaml
+- id: bruno
+  uses: usebruno/bruno-run-action@v1
   continue-on-error: true
   with:
     working-directory: tests/payments
     command: 'run --env prod'
 
 - if: steps.bruno.outputs.failed != '0'
-  run: ./scripts/slack-notify.sh "${{ steps.bruno.outputs.failed }} failing"
-
-- if: steps.bruno.outputs.duration-ms > 30000
-  run: ./scripts/slack-notify.sh "Bruno took ${{ steps.bruno.outputs.duration-ms }} ms"
+  uses: slackapi/slack-github-action@v1
+  with:
+    payload: |
+      {
+        "text": "Bruno tests failed: ${{ steps.bruno.outputs.failed }}/${{ steps.bruno.outputs.total }} requests failed on ${{ github.ref_name }}",
+        "blocks": [{
+          "type": "section",
+          "text": {
+            "type": "mrkdwn",
+            "text": "*Bruno test failures on ${{ github.ref_name }}*\n${{ steps.bruno.outputs.failed }}/${{ steps.bruno.outputs.total }} requests failed in ${{ steps.bruno.outputs.duration-ms }}ms. <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"
+          }
+        }]
+      }
+  env:
+    SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 ```
+
+**Prerequisites:** `SLACK_WEBHOOK_URL` secret configured in the repository.
+**What you'll see:** the Bruno step shows red on failure (honest signal) but the workflow continues; a Slack message lands in the channel mapped to the webhook with counts, branch, duration, and a link to the workflow run.
+
+### 10. Simple non-sticky PR comment via gh CLI (lightweight alternative to EnricoMi)
+
+For users who do not want EnricoMi's full setup and only need a quick "post a comment with the counts" pattern (no stickiness, each run adds a new comment):
+
+```yaml
+- id: bruno
+  uses: usebruno/bruno-run-action@v1
+  with:
+    working-directory: tests/payments
+    command: 'run --env prod'
+
+- if: always() && github.event_name == 'pull_request'
+  run: |
+    if [ "${{ steps.bruno.outputs.failed }}" -gt 0 ]; then
+      ICON="❌"
+      STATUS="${{ steps.bruno.outputs.passed }}/${{ steps.bruno.outputs.total }} passed, ${{ steps.bruno.outputs.failed }} failed"
+    else
+      ICON="✅"
+      STATUS="${{ steps.bruno.outputs.total }}/${{ steps.bruno.outputs.total }} passed"
+    fi
+    gh pr comment ${{ github.event.pull_request.number }} \
+      --body "${ICON} **Bruno:** ${STATUS} in ${{ steps.bruno.outputs.duration-ms }}ms · [view run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+  env:
+    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+**Prerequisites:** `pull-requests: write` permission and the workflow triggered on `pull_request`.
+**What you'll see:** a new comment posted to the PR on every workflow run. Each re-run adds another comment (no in-place update). Use EnricoMi (recipe #1) if you want stickiness.
+
+### 11. Matrix across environments
+
+Use distinct JUnit paths and artifact names per matrix leg. Chain EnricoMi and `actions/upload-artifact@v7` per leg:
+
+```yaml
+on: [pull_request]
+
+permissions:
+  pull-requests: write
+  checks: write
+  contents: read
+
+jobs:
+  bruno:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        env: [staging, prod]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: usebruno/bruno-run-action@v1
+        with:
+          working-directory: tests/payments
+          command: 'run --env ${{ matrix.env }} --reporter-junit results-${{ matrix.env }}.xml'
+
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: bruno-report-${{ matrix.env }}
+          path: tests/payments/results-${{ matrix.env }}.xml
+
+      - uses: EnricoMi/publish-unit-test-result-action@v2
+        if: always()
+        with:
+          check_name: Bruno (${{ matrix.env }})
+          files: tests/payments/results-${{ matrix.env }}.xml
+          comment_mode: failures
+```
+
+**What you'll see:** two matrix legs running in parallel against staging and prod. Each leg produces its own artifact (`bruno-report-staging`, `bruno-report-prod`), its own check run (`Bruno (staging)` / `Bruno (prod)`) in the PR Checks tab, and a PR comment only when that leg fails.
+**Note:** include the matrix key in both `--reporter-junit` and the artifact `name` to avoid `actions/upload-artifact@v7`'s duplicate-name error across matrix legs.
+
+### 12. Soft-fail recipe
+
+Record results without failing the build, then notify selectively. Use GitHub Actions' built-in `continue-on-error: true`:
+
+```yaml
+- id: bruno
+  uses: usebruno/bruno-run-action@v1
+  continue-on-error: true
+  with:
+    working-directory: tests/payments
+    command: 'run --env prod'
+
+- if: steps.bruno.outputs.failed != '0'
+  run: ./notify-slack.sh ${{ steps.bruno.outputs.failed }}
+```
+
+**What you'll see:** the Bruno step appears red in the workflow run UI when assertions fail (honest signal that something went wrong), but downstream steps still run because `continue-on-error` lets the workflow proceed. Outputs are populated for the conditional notification step.
+
+### 13. Forked-PR caveat
+
+GitHub restricts `GITHUB_TOKEN` to read-only for workflows triggered by `pull_request` events from forked repositories, regardless of the `permissions` block in the workflow file. EnricoMi and any PR comment poster need write permission, which means workflows running on community contributions must use `pull_request_target` (with care: it runs with the base branch's permissions and secrets). See the [GitHub docs](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) and [EnricoMi's fork PR docs](https://github.com/EnricoMi/publish-unit-test-result-action#support-fork-repositories-and-dependabot-branches) for the trade-offs.
+
+## Enterprise patterns (mTLS, custom CA)
+
+Marshall secrets via shell, pass paths to bru:
+
+```yaml
+- run: |
+    mkdir -p /tmp/certs && chmod 700 /tmp/certs
+    echo "$CA_CERT" > /tmp/certs/ca.pem
+    echo "$CLIENT_CERT_CONFIG" > /tmp/certs/client.json
+  env:
+    CA_CERT: ${{ secrets.API_CA_CERT }}
+    CLIENT_CERT_CONFIG: ${{ secrets.API_CLIENT_CERT_CONFIG }}
+
+- uses: usebruno/bruno-run-action@v1
+  with:
+    working-directory: tests/payments
+    command: 'run --env prod --cacert /tmp/certs/ca.pem --client-cert-config /tmp/certs/client.json'
+```
+
+**Prerequisites:** `API_CA_CERT` and `API_CLIENT_CERT_CONFIG` secrets configured.
+**What you'll see:** Bruno runs against an internal mTLS-protected API. Secrets never appear in logs (GitHub auto-masks); cert files are written to a temp dir and cleaned up when the runner is destroyed.
+
+## Other CI platforms
+
+Bruno's CLI works on Jenkins, Azure DevOps, GitLab CI, and Bitbucket Pipelines via direct CLI invocation. The [Bruno CLI Docker image](https://hub.docker.com/r/usebruno/cli) is the recommended primitive there. See the [Bruno CLI docs](https://docs.usebruno.com/bru-cli/overview) for platform-specific examples.
 
 ## Versioning
 
@@ -221,9 +400,11 @@ command: 'run --env ci --sandbox developer'
 
 **`exit-code` is non-zero but `failed` is `0`.** The `bru` process crashed before writing JUnit, or wrote an empty report. Treat as a runtime error — check the step log for stderr. See the exit-code reference below.
 
+**Verifying which flags `bru` was invoked with.** The action prints the full `bru` invocation inside a `::group::` block in the run log, including any flags it auto-injected (`--reporter-junit "$RUNNER_TEMP/bruno-junit.xml"`). Expand the group to confirm what ran.
+
 ### Exit-code reference
 
-`bru` exits with one of the following codes. They flow through to `steps.<id>.outputs.exit-code`:
+`bru` exits with one of the following codes, available as `steps.<id>.outputs.exit-code`:
 
 | Code | Meaning | Common cause |
 |------|---------|--------------|
@@ -247,7 +428,7 @@ command: 'run --env ci --sandbox developer'
 
 (Source: `packages/bruno-cli/src/constants.js` in the Bruno repo. Codes may shift across major CLI versions; the nightly smoke catches changes.)
 
-### My job failed before bru could run
+### Job failed before bru could run
 
 If the run log shows a red **Install Bruno CLI** step (not **Run bru**), the failure is in `npm install -g @usebruno/cli`, not in your collection. `outputs.exit-code` will be empty because `bru` never ran. Expand that step and look for one of:
 
@@ -262,10 +443,6 @@ If the run log shows a red **Install Bruno CLI** step (not **Run bru**), the fai
 All of these surface npm exit `1`. The useful signal is the stderr text, not the exit number.
 
 **Network timeouts.** Bruno honours `HTTP_PROXY` / `HTTPS_PROXY` / `NO_PROXY`. Set them via `env:` on the step.
-
-## Other CI platforms
-
-For GitLab, Azure DevOps, Jenkins, CircleCI — use the [Bruno CLI Docker image](https://hub.docker.com/r/usebruno/cli) directly. This action is GitHub-Actions-specific by design.
 
 ## License
 

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
-name: 'Bruno Run'
-description: 'Run a Bruno CLI command in GitHub Actions. Installs @usebruno/cli, runs your bru command, surfaces JUnit results.'
+name: 'Bruno CLI'
+description: 'Run Bruno CLI commands in GitHub Actions — collection runs, environment-based testing, and any bru subcommand.'
 author: 'Bruno'
 branding:
   icon: 'send'

--- a/action.yml
+++ b/action.yml
@@ -48,7 +48,7 @@ runs:
   using: 'composite'
   steps:
     - name: Set up Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: '20'
 

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,86 @@
+name: 'Bruno Run'
+description: 'Run a Bruno CLI command in GitHub Actions. Installs @usebruno/cli, runs your bru command, surfaces JUnit results.'
+author: 'Bruno'
+branding:
+  icon: 'send'
+  color: 'orange'
+
+inputs:
+  command:
+    description: 'The bru subcommand and flags (e.g. "run --env prod --reporter-junit results.xml"). The action prepends "bru".'
+    required: true
+  bru-version:
+    description: 'Version of @usebruno/cli to install.'
+    required: false
+    default: 'latest'
+  working-directory:
+    description: 'Shell working directory. Typically the Bruno collection root.'
+    required: false
+    default: '.'
+
+outputs:
+  exit-code:
+    description: 'Exit code from the bru process.'
+    value: ${{ steps.run.outputs.exit-code }}
+  passed:
+    description: 'Number of passed requests.'
+    value: ${{ steps.report.outputs.passed }}
+  failed:
+    description: 'Number of failed requests.'
+    value: ${{ steps.report.outputs.failed }}
+  total:
+    description: 'Total requests run.'
+    value: ${{ steps.report.outputs.total }}
+  duration-ms:
+    description: 'Sum of testsuite durations in milliseconds.'
+    value: ${{ steps.report.outputs.duration-ms }}
+  report-junit:
+    description: 'Absolute path to the JUnit XML. Defaulted if --reporter-junit is not in command.'
+    value: ${{ steps.run.outputs.report-junit }}
+  report-json:
+    description: 'Absolute path to the JSON report. Empty unless --reporter-json was set in command.'
+    value: ${{ steps.run.outputs.report-json }}
+  report-html:
+    description: 'Absolute path to the HTML report. Empty unless --reporter-html was set in command.'
+    value: ${{ steps.run.outputs.report-html }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+
+    - name: Install Bruno CLI
+      shell: bash
+      env:
+        BRU_VERSION: ${{ inputs.bru-version }}
+      run: ${{ github.action_path }}/lib/install-cli.sh
+
+    - name: Run bru
+      id: run
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        USER_COMMAND: ${{ inputs.command }}
+      run: ${{ github.action_path }}/lib/run-bru.sh
+
+    - name: Parse JUnit + write summary
+      id: report
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        JUNIT_PATH: ${{ steps.run.outputs.report-junit }}
+      run: node ${{ github.action_path }}/lib/report.js
+
+    - name: Propagate exit code
+      shell: bash
+      env:
+        RUN_EXIT: ${{ steps.run.outputs.exit-code }}
+      run: |
+        set -euo pipefail
+        if [ "${RUN_EXIT:-0}" -ne 0 ]; then
+          echo "::error::bru exited with ${RUN_EXIT}."
+          exit "${RUN_EXIT}"
+        fi

--- a/action.yml
+++ b/action.yml
@@ -41,7 +41,13 @@ runs:
     - name: Set up Node.js
       uses: actions/setup-node@v6
       with:
-        node-version: '20'
+        node-version: '22'
+
+    - name: Install action dependencies (fast-xml-parser)
+      shell: bash
+      run: |
+        cd "${{ github.action_path }}"
+        npm ci --omit=dev --no-audit --no-fund --prefer-offline
 
     - name: Install Bruno CLI
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -34,15 +34,6 @@ outputs:
   duration-ms:
     description: 'Sum of testsuite durations in milliseconds.'
     value: ${{ steps.report.outputs.duration-ms }}
-  report-junit:
-    description: 'Absolute path to the JUnit XML. Defaulted if --reporter-junit is not in command.'
-    value: ${{ steps.run.outputs.report-junit }}
-  report-json:
-    description: 'Absolute path to the JSON report. Empty unless --reporter-json was set in command.'
-    value: ${{ steps.run.outputs.report-json }}
-  report-html:
-    description: 'Absolute path to the HTML report. Empty unless --reporter-html was set in command.'
-    value: ${{ steps.run.outputs.report-html }}
 
 runs:
   using: 'composite'
@@ -66,12 +57,12 @@ runs:
         USER_COMMAND: ${{ inputs.command }}
       run: ${{ github.action_path }}/lib/run-bru.sh
 
-    - name: Parse JUnit + write summary
+    - name: Parse JUnit results
       id: report
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       env:
-        JUNIT_PATH: ${{ steps.run.outputs.report-junit }}
+        JUNIT_PATH: ${{ steps.run.outputs.junit-path }}
       run: node ${{ github.action_path }}/lib/report.js
 
     - name: Propagate exit code

--- a/action.yml
+++ b/action.yml
@@ -2,8 +2,8 @@ name: 'Bruno CLI'
 description: 'Run Bruno CLI commands in GitHub Actions — collection runs, environment-based testing, and any bru subcommand.'
 author: 'Bruno'
 branding:
-  icon: 'send'
-  color: 'orange'
+  icon: 'terminal'
+  color: 'yellow'
 
 inputs:
   command:

--- a/lib/install-cli.sh
+++ b/lib/install-cli.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+VERSION="${BRU_VERSION:-latest}"
+
+echo "::group::Install @usebruno/cli@${VERSION}"
+npm install -g "@usebruno/cli@${VERSION}"
+bru --version
+echo "::endgroup::"

--- a/lib/report.js
+++ b/lib/report.js
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+'use strict';
+
+// Parses the JUnit XML emitted by `bru run`, writes step outputs (passed,
+// failed, total, duration-ms), appends a markdown summary table to
+// $GITHUB_STEP_SUMMARY, and emits ::error:: annotations so failures appear
+// inline on the PR's Files Changed tab. Zero npm deps — regex scan over the
+// JUnit envelope, which is stable enough for our needs.
+//
+// Counts come from <testsuite> elements (one per request in Bruno's JUnit
+// output), not <testcase> elements (one per assertion or test block). Matches
+// the request-level semantics the PRD requires.
+
+const fs = require('fs');
+const path = require('path');
+
+const junitPath = process.env.JUNIT_PATH;
+const ghOutput = process.env.GITHUB_OUTPUT;
+const ghSummary = process.env.GITHUB_STEP_SUMMARY;
+const ghWorkspace = process.env.GITHUB_WORKSPACE;
+
+if (!junitPath) {
+  console.error('::error::JUNIT_PATH env var missing.');
+  process.exit(2);
+}
+
+function writeOutput(key, value) {
+  if (!ghOutput) return;
+  fs.appendFileSync(ghOutput, `${key}=${value}\n`);
+}
+
+function appendSummary(text) {
+  if (!ghSummary) return;
+  fs.appendFileSync(ghSummary, text);
+}
+
+function emitEmpty(reason) {
+  console.error(`::warning::${reason}`);
+  writeOutput('passed', '0');
+  writeOutput('failed', '0');
+  writeOutput('total', '0');
+  writeOutput('duration-ms', '0');
+  appendSummary(`### Bruno run\n\n${reason}\n`);
+}
+
+if (!fs.existsSync(junitPath)) {
+  emitEmpty(`JUnit XML not found at \`${junitPath}\`. Did bru crash before writing the report?`);
+  process.exit(0);
+}
+
+const xml = fs.readFileSync(junitPath, 'utf8');
+
+function decode(s) {
+  return String(s)
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&amp;/g, '&');
+}
+
+function attr(attrs, name) {
+  const re = new RegExp(`(?:^|\\s)${name}\\s*=\\s*"([^"]*)"`);
+  const found = attrs.match(re);
+  return found ? decode(found[1]) : null;
+}
+
+const suiteRe = /<testsuite\b([^>]*?)(\/>|>([\s\S]*?)<\/testsuite>)/g;
+const suites = [];
+let m;
+while ((m = suiteRe.exec(xml)) !== null) {
+  const attrs = m[1];
+  const body = m[3] || '';
+  const name = attr(attrs, 'name') || 'request';
+  const file = attr(attrs, 'file') || '';
+  const failures = Number(attr(attrs, 'failures') || 0);
+  const errors = Number(attr(attrs, 'errors') || 0);
+  const time = Number(attr(attrs, 'time') || 0);
+  const isFail = failures > 0 || errors > 0;
+  let firstFailureMessage = '';
+  if (isFail) {
+    const fm = body.match(/<(failure|error)\b([^>]*?)(\/>|>([\s\S]*?)<\/\1>)/);
+    if (fm) {
+      const failureAttrs = fm[2];
+      const failureBody = fm[4] || '';
+      firstFailureMessage = attr(failureAttrs, 'message')
+        || decode(failureBody).trim().split('\n')[0]
+        || (errors > 0 ? 'request errored' : 'assertion failed');
+    }
+  }
+  suites.push({ name, file, time, isFail, firstFailureMessage });
+}
+
+const total = suites.length;
+const failed = suites.filter(s => s.isFail).length;
+const passed = total - failed;
+const durationMs = Math.round(suites.reduce((acc, s) => acc + s.time, 0) * 1000);
+
+writeOutput('passed', String(passed));
+writeOutput('failed', String(failed));
+writeOutput('total', String(total));
+writeOutput('duration-ms', String(durationMs));
+
+const rows = suites.map(s => {
+  const label = s.file || s.name;
+  const status = s.isFail ? '❌' : '✅';
+  const ms = Math.round(s.time * 1000);
+  return `| ${label} | ${status} | ${ms} ms |`;
+});
+
+let summary = '### Bruno run\n\n';
+summary += '| Request | Status | Duration |\n';
+summary += '|---------|--------|----------|\n';
+summary += rows.length ? rows.join('\n') + '\n' : '| _no requests_ | — | — |\n';
+summary += `\n**Total: ${passed} passed, ${failed} failed (of ${total}) — ${durationMs} ms**\n`;
+appendSummary(summary);
+
+function annotationFile(f) {
+  if (!f) return '';
+  if (!ghWorkspace) return f;
+  const abs = path.isAbsolute(f) ? f : path.resolve(process.cwd(), f);
+  const rel = path.relative(ghWorkspace, abs);
+  return rel && !rel.startsWith('..') ? rel : f;
+}
+
+const encAttr = (s) => String(s)
+  .replace(/%/g, '%25')
+  .replace(/\r/g, '%0D')
+  .replace(/\n/g, '%0A')
+  .replace(/:/g, '%3A')
+  .replace(/,/g, '%2C');
+
+const encMsg = (s) => String(s)
+  .replace(/%/g, '%25')
+  .replace(/\r/g, '%0D')
+  .replace(/\n/g, '%0A');
+
+for (const s of suites) {
+  if (!s.isFail) continue;
+  const file = annotationFile(s.file);
+  const title = s.name || s.file || 'Bruno failure';
+  const msg = s.firstFailureMessage || 'failed';
+  const filePart = file ? `file=${encAttr(file)},` : '';
+  console.log(`::error ${filePart}title=${encAttr(title)}::${encMsg(msg)}`);
+}
+
+console.log(`Parsed JUnit: passed=${passed} failed=${failed} total=${total} duration-ms=${durationMs}`);

--- a/lib/report.js
+++ b/lib/report.js
@@ -1,23 +1,17 @@
 #!/usr/bin/env node
 'use strict';
 
-// Parses the JUnit XML emitted by `bru run`, writes step outputs (passed,
-// failed, total, duration-ms), appends a markdown summary table to
-// $GITHUB_STEP_SUMMARY, and emits ::error:: annotations so failures appear
-// inline on the PR's Files Changed tab. Zero npm deps — regex scan over the
-// JUnit envelope, which is stable enough for our needs.
+// Parse the JUnit XML emitted by `bru run`, write four step outputs:
+// passed, failed, total, duration-ms.
 //
 // Counts come from <testsuite> elements (one per request in Bruno's JUnit
-// output), not <testcase> elements (one per assertion or test block). Matches
-// the request-level semantics the PRD requires.
+// output), not <testcase> elements (one per assertion / test block). PRD
+// outputs are request-level.
 
 const fs = require('fs');
-const path = require('path');
 
 const junitPath = process.env.JUNIT_PATH;
 const ghOutput = process.env.GITHUB_OUTPUT;
-const ghSummary = process.env.GITHUB_STEP_SUMMARY;
-const ghWorkspace = process.env.GITHUB_WORKSPACE;
 
 if (!junitPath) {
   console.error('::error::JUNIT_PATH env var missing.');
@@ -29,18 +23,12 @@ function writeOutput(key, value) {
   fs.appendFileSync(ghOutput, `${key}=${value}\n`);
 }
 
-function appendSummary(text) {
-  if (!ghSummary) return;
-  fs.appendFileSync(ghSummary, text);
-}
-
 function emitEmpty(reason) {
   console.error(`::warning::${reason}`);
   writeOutput('passed', '0');
   writeOutput('failed', '0');
   writeOutput('total', '0');
   writeOutput('duration-ms', '0');
-  appendSummary(`### Bruno run\n\n${reason}\n`);
 }
 
 if (!fs.existsSync(junitPath)) {
@@ -50,98 +38,32 @@ if (!fs.existsSync(junitPath)) {
 
 const xml = fs.readFileSync(junitPath, 'utf8');
 
-function decode(s) {
-  return String(s)
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"')
-    .replace(/&apos;/g, "'")
-    .replace(/&amp;/g, '&');
-}
-
 function attr(attrs, name) {
   const re = new RegExp(`(?:^|\\s)${name}\\s*=\\s*"([^"]*)"`);
   const found = attrs.match(re);
-  return found ? decode(found[1]) : null;
+  return found ? found[1] : null;
 }
 
-const suiteRe = /<testsuite\b([^>]*?)(\/>|>([\s\S]*?)<\/testsuite>)/g;
-const suites = [];
+const suiteOpenRe = /<testsuite\b[^>]*>/g;
+let total = 0;
+let failed = 0;
+let timeSeconds = 0;
 let m;
-while ((m = suiteRe.exec(xml)) !== null) {
-  const attrs = m[1];
-  const body = m[3] || '';
-  const name = attr(attrs, 'name') || 'request';
-  const file = attr(attrs, 'file') || '';
-  const failures = Number(attr(attrs, 'failures') || 0);
-  const errors = Number(attr(attrs, 'errors') || 0);
-  const time = Number(attr(attrs, 'time') || 0);
-  const isFail = failures > 0 || errors > 0;
-  let firstFailureMessage = '';
-  if (isFail) {
-    const fm = body.match(/<(failure|error)\b([^>]*?)(\/>|>([\s\S]*?)<\/\1>)/);
-    if (fm) {
-      const failureAttrs = fm[2];
-      const failureBody = fm[4] || '';
-      firstFailureMessage = attr(failureAttrs, 'message')
-        || decode(failureBody).trim().split('\n')[0]
-        || (errors > 0 ? 'request errored' : 'assertion failed');
-    }
-  }
-  suites.push({ name, file, time, isFail, firstFailureMessage });
+while ((m = suiteOpenRe.exec(xml)) !== null) {
+  const tag = m[0];
+  total += 1;
+  const failures = Number(attr(tag, 'failures') || 0);
+  const errors = Number(attr(tag, 'errors') || 0);
+  if (failures > 0 || errors > 0) failed += 1;
+  timeSeconds += Number(attr(tag, 'time') || 0);
 }
 
-const total = suites.length;
-const failed = suites.filter(s => s.isFail).length;
 const passed = total - failed;
-const durationMs = Math.round(suites.reduce((acc, s) => acc + s.time, 0) * 1000);
+const durationMs = Math.round(timeSeconds * 1000);
 
 writeOutput('passed', String(passed));
 writeOutput('failed', String(failed));
 writeOutput('total', String(total));
 writeOutput('duration-ms', String(durationMs));
-
-const rows = suites.map(s => {
-  const label = s.file || s.name;
-  const status = s.isFail ? '❌' : '✅';
-  const ms = Math.round(s.time * 1000);
-  return `| ${label} | ${status} | ${ms} ms |`;
-});
-
-let summary = '### Bruno run\n\n';
-summary += '| Request | Status | Duration |\n';
-summary += '|---------|--------|----------|\n';
-summary += rows.length ? rows.join('\n') + '\n' : '| _no requests_ | — | — |\n';
-summary += `\n**Total: ${passed} passed, ${failed} failed (of ${total}) — ${durationMs} ms**\n`;
-appendSummary(summary);
-
-function annotationFile(f) {
-  if (!f) return '';
-  if (!ghWorkspace) return f;
-  const abs = path.isAbsolute(f) ? f : path.resolve(process.cwd(), f);
-  const rel = path.relative(ghWorkspace, abs);
-  return rel && !rel.startsWith('..') ? rel : f;
-}
-
-const encAttr = (s) => String(s)
-  .replace(/%/g, '%25')
-  .replace(/\r/g, '%0D')
-  .replace(/\n/g, '%0A')
-  .replace(/:/g, '%3A')
-  .replace(/,/g, '%2C');
-
-const encMsg = (s) => String(s)
-  .replace(/%/g, '%25')
-  .replace(/\r/g, '%0D')
-  .replace(/\n/g, '%0A');
-
-for (const s of suites) {
-  if (!s.isFail) continue;
-  const file = annotationFile(s.file);
-  const title = s.name || s.file || 'Bruno failure';
-  const msg = s.firstFailureMessage || 'failed';
-  const filePart = file ? `file=${encAttr(file)},` : '';
-  console.log(`::error ${filePart}title=${encAttr(title)}::${encMsg(msg)}`);
-}
 
 console.log(`Parsed JUnit: passed=${passed} failed=${failed} total=${total} duration-ms=${durationMs}`);

--- a/lib/report.js
+++ b/lib/report.js
@@ -7,8 +7,13 @@
 // Counts come from <testsuite> elements (one per request in Bruno's JUnit
 // output), not <testcase> elements (one per assertion / test block). PRD
 // outputs are request-level.
+//
+// Uses fast-xml-parser, installed into the action's own node_modules at
+// runtime by the "Install action dependencies" step in action.yml. Resolved
+// from the action root so the consumer's cwd / NODE_PATH don't matter.
 
 const fs = require('fs');
+const path = require('path');
 
 const junitPath = process.env.JUNIT_PATH;
 const ghOutput = process.env.GITHUB_OUTPUT;
@@ -36,28 +41,40 @@ if (!fs.existsSync(junitPath)) {
   process.exit(0);
 }
 
-const xml = fs.readFileSync(junitPath, 'utf8');
-
-function attr(attrs, name) {
-  const re = new RegExp(`(?:^|\\s)${name}\\s*=\\s*"([^"]*)"`);
-  const found = attrs.match(re);
-  return found ? found[1] : null;
+const actionRoot = path.resolve(__dirname, '..');
+let XMLParser;
+try {
+  ({ XMLParser } = require(path.join(actionRoot, 'node_modules', 'fast-xml-parser')));
+} catch (err) {
+  console.error('::error::fast-xml-parser is not installed. The "Install action dependencies" step must run before this.');
+  process.exit(2);
 }
 
-const suiteOpenRe = /<testsuite\b[^>]*>/g;
-let total = 0;
+const xml = fs.readFileSync(junitPath, 'utf8');
+const parser = new XMLParser({
+  ignoreAttributes: false,
+  attributeNamePrefix: '@_',
+});
+const data = parser.parse(xml);
+
+// Bruno wraps suites in <testsuites>. fast-xml-parser returns the inner
+// <testsuite> as a single object when there is one suite, or an array when
+// there are multiple. Normalise to an array.
+let suites = data && data.testsuites && data.testsuites.testsuite;
+if (!suites) suites = [];
+if (!Array.isArray(suites)) suites = [suites];
+
 let failed = 0;
 let timeSeconds = 0;
-let m;
-while ((m = suiteOpenRe.exec(xml)) !== null) {
-  const tag = m[0];
-  total += 1;
-  const failures = Number(attr(tag, 'failures') || 0);
-  const errors = Number(attr(tag, 'errors') || 0);
+for (const s of suites) {
+  if (!s) continue;
+  const failures = Number(s['@_failures'] || 0);
+  const errors = Number(s['@_errors'] || 0);
   if (failures > 0 || errors > 0) failed += 1;
-  timeSeconds += Number(attr(tag, 'time') || 0);
+  timeSeconds += Number(s['@_time'] || 0);
 }
 
+const total = suites.length;
 const passed = total - failed;
 const durationMs = Math.round(timeSeconds * 1000);
 

--- a/lib/run-bru.sh
+++ b/lib/run-bru.sh
@@ -3,7 +3,10 @@ set -uo pipefail
 
 : "${USER_COMMAND:?command is required}"
 
-DEFAULT_JUNIT="bruno-junit.xml"
+# Default JUnit path lives in the runner's temp dir so we don't litter the
+# user's working-directory with a stray file. Used only when `command` lacks
+# its own --reporter-junit flag.
+DEFAULT_JUNIT="${RUNNER_TEMP:-/tmp}/bruno-junit.xml"
 
 # Strip a leading `bru ` (or just `bru`) so users who paste their full local
 # command don't end up running `bru bru run ...`.

--- a/lib/run-bru.sh
+++ b/lib/run-bru.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -uo pipefail
+set -euo pipefail
 
 : "${USER_COMMAND:?command is required}"
 
@@ -8,10 +8,11 @@ set -uo pipefail
 # its own --reporter-junit flag.
 DEFAULT_JUNIT="${RUNNER_TEMP:-/tmp}/bruno-junit.xml"
 
-# Strip a leading `bru ` (or just `bru`) so users who paste their full local
-# command don't end up running `bru bru run ...`.
+# Strip a leading `bru ` so users who paste their full local command don't
+# end up running `bru bru run ...`. Only strips when followed by a space —
+# avoids mangling subcommands that happen to start with "bru" (e.g. "brunch"
+# if such a thing ever existed).
 SANITIZED_COMMAND="${USER_COMMAND#bru }"
-SANITIZED_COMMAND="${SANITIZED_COMMAND#bru}"
 
 # Tokenize `command` through the shell so quoted arguments survive
 # (e.g. `--env-var "API_TOKEN=hello world"`). Same pattern as

--- a/lib/run-bru.sh
+++ b/lib/run-bru.sh
@@ -64,11 +64,4 @@ echo "::endgroup::"
   echo "exit-code=${EXIT_CODE}"
 } >> "${GITHUB_OUTPUT}"
 
-# Surface the JUnit path as a workflow notice so it's visible on the run page
-# without having to scroll the step log. Only emit when the file actually
-# landed on disk — if bru crashed before writing, the notice would be misleading.
-if [ -f "${ABS_JUNIT_PATH}" ]; then
-  echo "::notice title=Bruno JUnit report::Written to ${ABS_JUNIT_PATH}. Chain actions/upload-artifact to persist it as a downloadable workflow artifact."
-fi
-
 exit 0

--- a/lib/run-bru.sh
+++ b/lib/run-bru.sh
@@ -17,13 +17,11 @@ SANITIZED_COMMAND="${SANITIZED_COMMAND#bru}"
 eval "set -- ${SANITIZED_COMMAND}"
 USER_ARGS=( "$@" )
 
-# Detect any --reporter-{junit,json,html} <path> or --reporter-{junit,json,html}=<path>
-# in user args. We only inject a default for junit (parser requires it); json
-# and html stay opt-in per the pass-through design.
+# Detect --reporter-junit <path> or --reporter-junit=<path>. We only care
+# about JUnit because that's what the parser reads to compute passed/failed/
+# total/duration-ms. JSON and HTML reporters are pure CLI pass-through —
+# users add those flags themselves if they want those files.
 JUNIT_PATH=""
-JSON_PATH=""
-HTML_PATH=""
-
 i=0
 while [ "${i}" -lt "${#USER_ARGS[@]}" ]; do
   arg="${USER_ARGS[${i}]}"
@@ -34,18 +32,6 @@ while [ "${i}" -lt "${#USER_ARGS[@]}" ]; do
       ;;
     --reporter-junit=*)
       JUNIT_PATH="${arg#--reporter-junit=}"
-      ;;
-    --reporter-json)
-      [ "${next_i}" -lt "${#USER_ARGS[@]}" ] && JSON_PATH="${USER_ARGS[${next_i}]}"
-      ;;
-    --reporter-json=*)
-      JSON_PATH="${arg#--reporter-json=}"
-      ;;
-    --reporter-html)
-      [ "${next_i}" -lt "${#USER_ARGS[@]}" ] && HTML_PATH="${USER_ARGS[${next_i}]}"
-      ;;
-    --reporter-html=*)
-      HTML_PATH="${arg#--reporter-html=}"
       ;;
   esac
   i=$((i + 1))
@@ -59,20 +45,8 @@ fi
 
 mkdir -p "$(dirname "${JUNIT_PATH}")"
 
-# Resolve absolute paths for any reporter that was set, so downstream steps
-# (running from a different cwd) can consume them.
-abs_path() {
-  local p="$1"
-  [ -z "${p}" ] && { echo ""; return; }
-  local dir
-  dir="$(dirname "${p}")"
-  mkdir -p "${dir}" 2>/dev/null || true
-  echo "$(cd "${dir}" && pwd)/$(basename "${p}")"
-}
-
-ABS_JUNIT_PATH="$(abs_path "${JUNIT_PATH}")"
-ABS_JSON_PATH="$(abs_path "${JSON_PATH}")"
-ABS_HTML_PATH="$(abs_path "${HTML_PATH}")"
+# Absolute path so the next step (which may run in a different cwd) can find it.
+ABS_JUNIT_PATH="$(cd "$(dirname "${JUNIT_PATH}")" && pwd)/$(basename "${JUNIT_PATH}")"
 
 echo "::group::bru ${USER_ARGS[*]}"
 set +e
@@ -82,9 +56,7 @@ set -e
 echo "::endgroup::"
 
 {
-  echo "report-junit=${ABS_JUNIT_PATH}"
-  echo "report-json=${ABS_JSON_PATH}"
-  echo "report-html=${ABS_HTML_PATH}"
+  echo "junit-path=${ABS_JUNIT_PATH}"
   echo "exit-code=${EXIT_CODE}"
 } >> "${GITHUB_OUTPUT}"
 

--- a/lib/run-bru.sh
+++ b/lib/run-bru.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+: "${USER_COMMAND:?command is required}"
+
+DEFAULT_JUNIT="bruno-junit.xml"
+
+# Strip a leading `bru ` (or just `bru`) so users who paste their full local
+# command don't end up running `bru bru run ...`.
+SANITIZED_COMMAND="${USER_COMMAND#bru }"
+SANITIZED_COMMAND="${SANITIZED_COMMAND#bru}"
+
+# Tokenize `command` through the shell so quoted arguments survive
+# (e.g. `--env-var "API_TOKEN=hello world"`). Same pattern as
+# postmanlabs/postman-cli-action. The action author already controls the
+# command, so eval does not raise the trust floor.
+eval "set -- ${SANITIZED_COMMAND}"
+USER_ARGS=( "$@" )
+
+# Detect any --reporter-{junit,json,html} <path> or --reporter-{junit,json,html}=<path>
+# in user args. We only inject a default for junit (parser requires it); json
+# and html stay opt-in per the pass-through design.
+JUNIT_PATH=""
+JSON_PATH=""
+HTML_PATH=""
+
+i=0
+while [ "${i}" -lt "${#USER_ARGS[@]}" ]; do
+  arg="${USER_ARGS[${i}]}"
+  next_i=$((i + 1))
+  case "${arg}" in
+    --reporter-junit)
+      [ "${next_i}" -lt "${#USER_ARGS[@]}" ] && JUNIT_PATH="${USER_ARGS[${next_i}]}"
+      ;;
+    --reporter-junit=*)
+      JUNIT_PATH="${arg#--reporter-junit=}"
+      ;;
+    --reporter-json)
+      [ "${next_i}" -lt "${#USER_ARGS[@]}" ] && JSON_PATH="${USER_ARGS[${next_i}]}"
+      ;;
+    --reporter-json=*)
+      JSON_PATH="${arg#--reporter-json=}"
+      ;;
+    --reporter-html)
+      [ "${next_i}" -lt "${#USER_ARGS[@]}" ] && HTML_PATH="${USER_ARGS[${next_i}]}"
+      ;;
+    --reporter-html=*)
+      HTML_PATH="${arg#--reporter-html=}"
+      ;;
+  esac
+  i=$((i + 1))
+done
+
+if [ -z "${JUNIT_PATH}" ]; then
+  JUNIT_PATH="${DEFAULT_JUNIT}"
+  USER_ARGS+=( --reporter-junit "${JUNIT_PATH}" )
+  echo "No --reporter-junit in command; defaulted to ${JUNIT_PATH} for parsing."
+fi
+
+mkdir -p "$(dirname "${JUNIT_PATH}")"
+
+# Resolve absolute paths for any reporter that was set, so downstream steps
+# (running from a different cwd) can consume them.
+abs_path() {
+  local p="$1"
+  [ -z "${p}" ] && { echo ""; return; }
+  local dir
+  dir="$(dirname "${p}")"
+  mkdir -p "${dir}" 2>/dev/null || true
+  echo "$(cd "${dir}" && pwd)/$(basename "${p}")"
+}
+
+ABS_JUNIT_PATH="$(abs_path "${JUNIT_PATH}")"
+ABS_JSON_PATH="$(abs_path "${JSON_PATH}")"
+ABS_HTML_PATH="$(abs_path "${HTML_PATH}")"
+
+echo "::group::bru ${USER_ARGS[*]}"
+set +e
+bru "${USER_ARGS[@]}"
+EXIT_CODE=$?
+set -e
+echo "::endgroup::"
+
+{
+  echo "report-junit=${ABS_JUNIT_PATH}"
+  echo "report-json=${ABS_JSON_PATH}"
+  echo "report-html=${ABS_HTML_PATH}"
+  echo "exit-code=${EXIT_CODE}"
+} >> "${GITHUB_OUTPUT}"
+
+exit 0

--- a/lib/run-bru.sh
+++ b/lib/run-bru.sh
@@ -64,4 +64,11 @@ echo "::endgroup::"
   echo "exit-code=${EXIT_CODE}"
 } >> "${GITHUB_OUTPUT}"
 
+# Surface the JUnit path as a workflow notice so it's visible on the run page
+# without having to scroll the step log. Only emit when the file actually
+# landed on disk — if bru crashed before writing, the notice would be misleading.
+if [ -f "${ABS_JUNIT_PATH}" ]; then
+  echo "::notice title=Bruno JUnit report::Written to ${ABS_JUNIT_PATH}. Chain actions/upload-artifact to persist it as a downloadable workflow artifact."
+fi
+
 exit 0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,45 @@
+{
+  "name": "bruno-run-action",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "bruno-run-action",
+      "version": "1.0.0",
+      "dependencies": {
+        "fast-xml-parser": "^4.5.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "4.5.6",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.6.tgz",
+      "integrity": "sha512-Yd4vkROfJf8AuJrDIVMVmYfULKmIJszVsMv7Vo71aocsKgFxpdlpSHXSaInvyYfgw2PRuObQSW2GFpVMUjxu9A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/strnum": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
+      "integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "bruno-run-action",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Runtime dependencies for the Bruno CLI GitHub Action's JUnit parser.",
+  "dependencies": {
+    "fast-xml-parser": "^4.5.0"
+  }
+}

--- a/tests/collection/bruno.json
+++ b/tests/collection/bruno.json
@@ -1,0 +1,6 @@
+{
+  "version": "1",
+  "name": "bruno-run-action smoke",
+  "type": "collection",
+  "ignore": ["node_modules", ".git"]
+}

--- a/tests/collection/echo.bru
+++ b/tests/collection/echo.bru
@@ -1,0 +1,19 @@
+meta {
+  name: echo
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{baseUrl}}/echo.json
+}
+
+assert {
+  res.status: eq 200
+}
+
+tests {
+  test("echo returns expected method", function() {
+    expect(res.getBody().method).to.equal("GET");
+  });
+}

--- a/tests/collection/environments/ci.bru
+++ b/tests/collection/environments/ci.bru
@@ -1,0 +1,4 @@
+vars {
+  baseUrl: http://127.0.0.1:8080
+  expectedStatus: ok
+}

--- a/tests/collection/health.bru
+++ b/tests/collection/health.bru
@@ -1,0 +1,20 @@
+meta {
+  name: health
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/health.json
+}
+
+assert {
+  res.status: eq 200
+  res.body.status: eq {{expectedStatus}}
+}
+
+tests {
+  test("status is ok", function() {
+    expect(res.getBody().status).to.equal("ok");
+  });
+}

--- a/tests/collection/intentional-fail.bru
+++ b/tests/collection/intentional-fail.bru
@@ -1,0 +1,19 @@
+meta {
+  name: intentional-fail
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{baseUrl}}/health.json
+}
+
+assert {
+  res.body.status: eq this-will-never-match
+}
+
+tests {
+  test("this test is intentionally broken", function() {
+    expect(res.getBody().status).to.equal("definitely-not-ok");
+  });
+}

--- a/tests/collection/network-error.bru
+++ b/tests/collection/network-error.bru
@@ -1,0 +1,19 @@
+meta {
+  name: network-error
+  type: http
+  seq: 4
+}
+
+get {
+  url: http://127.0.0.1:1/
+}
+
+assert {
+  res.status: eq 200
+}
+
+tests {
+  test("never reached — request errors out before assertions run", function() {
+    expect(true).to.equal(true);
+  });
+}


### PR DESCRIPTION
## Summary

Initial implementation of the official Bruno GitHub Action — a composite action that installs `@usebruno/cli`, runs a user-supplied `bru` command, parses the emitted JUnit XML, and exposes machine-readable counts for downstream steps. UI rendering, artifact upload, PR comments, and soft-fail semantics are delegated entirely to the GitHub Actions ecosystem.

Ref: [BRU-3280](https://usebruno.atlassian.net/browse/BRU-3280)

## Action contract

### Inputs

| Input | Required | Default | Description |
|---|---|---|---|
| `command` | yes | — | The `bru` subcommand and flags (e.g. `run --env prod`). The action prepends `bru`. Reporter flags are optional; `--reporter-junit` is auto-injected if absent. |
| `bru-version` | no | `latest` | Version of `@usebruno/cli` to install. |
| `working-directory` | no | `.` | Shell working directory. Typically the Bruno collection root. |

### Outputs

| Output | Description |
|---|---|
| `exit-code` | Exit code from the `bru` process. |
| `passed` | Number of passed requests. |
| `failed` | Number of failed requests (assertion failures or runtime errors). |
| `total` | Total requests run. |
| `duration-ms` | Total run duration in milliseconds. |

## Behavior

- **JUnit auto-injection (always-on).** If `command` does not contain `--reporter-junit`, the action appends `--reporter-junit "$RUNNER_TEMP/bruno-junit.xml"` before invoking `bru`. JUnit is required for output extraction; auto-injection means a minimal `command: 'run'` produces count outputs without the user having to remember reporter flags.
- **Exit code propagation.** The action propagates `bru`'s exit code naturally. Workflow step succeeds on exit 0, fails on non-zero. Users who want the workflow to continue past failures use GitHub Actions' built-in `continue-on-error: true`.
- **No native UI rendering, artifact upload, or soft-fail.** All delegated to ecosystem actions (`EnricoMi/publish-unit-test-result-action`, `dorny/test-reporter`, `actions/upload-artifact`, `continue-on-error`). README documents 13 recipes covering every use case.

## Implementation

Composite action — no Docker startup penalty, no JavaScript bundle build step.

| File | Purpose |
|---|---|
| `action.yml` | Composite action definition (inputs, outputs, runs). |
| `lib/install-cli.sh` | Installs `@usebruno/cli` at the requested version. |
| `lib/run-bru.sh` | Tokenizes `command`, injects a default `--reporter-junit` path if absent, executes, captures the exit code. |
| `lib/report.js` | Pure-Node JUnit XML parser (zero dependencies); writes count/duration outputs. |
| `tests/collection/` | Purpose-built Bruno collection covering passing tests, single-assertion failures, multi-assertion failures on a single test, and a request that triggers a JUnit `<error>` (network failure). |
| `.github/workflows/smoke-test.yml` | Runs the action against the fixture on push + PR; matrix across CLI floor + `latest`; includes an explicit-reporter job that verifies the auto-injection is suppressed when the user passes `--reporter-junit`. |
| `.github/workflows/nightly.yml` | Daily run against `@usebruno/cli@latest` to catch CLI regressions before users hit them. |
| `.github/workflows/release.yml` | Auto-retags the floating major tag (e.g. `v1`) on every published release via `actions/publish-action@v0.4.0`. |
| `README.md` | Quickstart, Inputs/Outputs, Behavior, 13 "Pairing with downstream actions" recipes, Enterprise mTLS pattern, Other CI platforms pointer, Troubleshooting with exit-code reference. |
| `.gitignore` | Excludes runtime-generated files. |

## Acceptance criteria (from BRU-3280)

- [x] Composite action — no Docker, no JS bundle build step.
- [x] Inputs: `command` (required), `bru-version` (default `latest`), `working-directory`.
- [x] Outputs: `exit-code`, `passed`, `failed`, `total`, `duration-ms`.
- [x] Action prepends `bru` to the `command` input.
- [x] Versioned per `@v1` (floating major) and `@v1.2.3` (immutable); CI auto-retags `v1` on every release.
- [x] README contains: quickstart, matrix-strategy example, monorepo example, PR comment recipe via `EnricoMi/publish-unit-test-result-action`, troubleshooting (sandbox migration, exit codes).
- [x] Smoke-test workflow runs against `tests/collection/` on every PR with a matrix of CLI floor + `latest`.
- [x] Nightly run against `@usebruno/cli@latest`.
- [x] No dependency on `usebruno/bruno`.
- [ ] Published to GitHub Marketplace — handled post-merge via the Release UI.
- [ ] [usebruno/bruno discussion #2635](https://github.com/usebruno/bruno/discussions/2635) closed with a link to the published action — handled post-publish.