### PR TITLE
docs: drop comparison line referencing other vendor actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ Official GitHub Action for running [Bruno](https://www.usebruno.com) CLI command
 
 Installs `@usebruno/cli`, runs an arbitrary `bru` command, parses the emitted JUnit XML, and exposes machine-readable counts (`exit-code`, `passed`, `failed`, `total`, `duration-ms`) for downstream steps. UI rendering, artifact upload, PR comments, and soft-fail semantics are delegated to the GitHub Actions ecosystem (`EnricoMi/publish-unit-test-result-action`, `dorny/test-reporter`, `actions/upload-artifact`, `continue-on-error`). See [Pairing with downstream actions](#pairing-with-downstream-actions) for canonical recipes.
 
-Design pattern follows [`postmanlabs/postman-cli-action`](https://github.com/postmanlabs/postman-cli-action) and [`kong/setup-inso`](https://github.com/kong/setup-inso): minimal-input pass-through, no flag mirroring.
-
 ## Quickstart
 
 ```yaml


### PR DESCRIPTION
Removes the README intro line:

> Design pattern follows \`postmanlabs/postman-cli-action\` and \`kong/setup-inso\`: minimal-input pass-through, no flag mirroring.

Keeps the README focused on what this action does for Bruno users without anchoring on comparisons to other vendors' actions. The design intent the line summarised is already evident from the Inputs/Outputs tables and the Pairing-with-downstream-actions section.

Pure docs change. Single-line removal.